### PR TITLE
Expand structured editor for mode, period, and validation state

### DIFF
--- a/tests/ui_logic.test.mjs
+++ b/tests/ui_logic.test.mjs
@@ -4,15 +4,20 @@ import assert from "node:assert/strict";
 import {
   applyEditableFieldsToPayload,
   buildFunctionAnalysisModel,
+  buildPeriodSource,
   buildPlanComparison,
   buildSummaryModel,
   getUtilizationStatus,
   readEditableFieldsFromPayload,
+  validateInputPayload,
 } from "../ui/app.js";
 
 test("readEditableFieldsFromPayload reflects pasted JSON values", () => {
   const editableFields = readEditableFieldsFromPayload({
-    planning_horizon: "year",
+    planning_mode: "capacity_check",
+    planning_horizon: "quarter",
+    calendar_year: 2026,
+    quarter_index: 2,
     working_days: 220,
     holidays_days: 12,
     vacation_days: 18,
@@ -23,7 +28,14 @@ test("readEditableFieldsFromPayload reflects pasted JSON values", () => {
   });
 
   assert.deepEqual(editableFields, {
-    planning_horizon: "year",
+    planning_mode: "capacity_check",
+    planning_horizon: "quarter",
+    calendar_year: 2026,
+    half_year_index: "",
+    quarter_index: 2,
+    month_index: "",
+    start_date: "",
+    end_date: "",
     working_days: 220,
     holidays_days: 12,
     vacation_days: 18,
@@ -32,6 +44,20 @@ test("readEditableFieldsFromPayload reflects pasted JSON values", () => {
     sprint_days: 15,
     overhead_days_per_sprint: 3,
   });
+});
+
+test("readEditableFieldsFromPayload includes sprint period selectors when present", () => {
+  const editableFields = readEditableFieldsFromPayload({
+    planning_mode: "planning_schedule",
+    planning_horizon: "sprint",
+    start_date: "2026-06-01",
+    end_date: "2026-06-14",
+  });
+
+  assert.equal(editableFields.planning_mode, "planning_schedule");
+  assert.equal(editableFields.start_date, "2026-06-01");
+  assert.equal(editableFields.end_date, "2026-06-14");
+  assert.equal(editableFields.calendar_year, "");
 });
 
 test("applyEditableFieldsToPayload preserves unrelated pasted JSON values", () => {
@@ -130,6 +156,130 @@ test("applyEditableFieldsToPayload retains existing sprint dates when switching 
 
   assert.equal(updated.start_date, "2026-05-05");
   assert.equal(updated.end_date, "2026-05-19");
+});
+
+test("applyEditableFieldsToPayload sets planning_mode from form value", () => {
+  const original = {
+    planning_horizon: "quarter",
+    calendar_year: 2026,
+    quarter_index: 1,
+    roadmap: {features: []},
+  };
+
+  const updated = applyEditableFieldsToPayload(original, {
+    planning_mode: "planning_schedule",
+    planning_horizon: "quarter",
+    working_days: "",
+    holidays_days: "",
+    vacation_days: "",
+    sick_days: "",
+    focus_factor: "",
+    sprint_days: "",
+    overhead_days_per_sprint: "",
+  });
+
+  assert.equal(updated.planning_mode, "planning_schedule");
+  assert.equal(updated.planning_horizon, "quarter");
+});
+
+test("applyEditableFieldsToPayload uses explicit calendar_year from form", () => {
+  const original = {
+    planning_horizon: "quarter",
+    calendar_year: 2025,
+    quarter_index: 1,
+    roadmap: {features: []},
+  };
+
+  const updated = applyEditableFieldsToPayload(original, {
+    planning_horizon: "quarter",
+    calendar_year: "2027",
+    quarter_index: "3",
+    working_days: "",
+    holidays_days: "",
+    vacation_days: "",
+    sick_days: "",
+    focus_factor: "",
+    sprint_days: "",
+    overhead_days_per_sprint: "",
+  });
+
+  assert.equal(updated.calendar_year, 2027);
+  assert.equal(updated.quarter_index, 3);
+});
+
+test("applyEditableFieldsToPayload uses explicit sprint dates from form", () => {
+  const original = {
+    planning_horizon: "sprint",
+    start_date: "2026-01-01",
+    end_date: "2026-01-14",
+    roadmap: {features: []},
+  };
+
+  const updated = applyEditableFieldsToPayload(original, {
+    planning_horizon: "sprint",
+    start_date: "2026-09-01",
+    end_date: "2026-09-14",
+    working_days: "",
+    holidays_days: "",
+    vacation_days: "",
+    sick_days: "",
+    focus_factor: "",
+    sprint_days: "",
+    overhead_days_per_sprint: "",
+  });
+
+  assert.equal(updated.start_date, "2026-09-01");
+  assert.equal(updated.end_date, "2026-09-14");
+});
+
+test("applyEditableFieldsToPayload ignores empty-string period selector form values", () => {
+  const original = {
+    planning_horizon: "quarter",
+    calendar_year: 2026,
+    quarter_index: 2,
+    roadmap: {features: []},
+  };
+
+  // Empty string calendar_year should fall back to inferring from source
+  const updated = applyEditableFieldsToPayload(original, {
+    planning_horizon: "quarter",
+    calendar_year: "",
+    quarter_index: "",
+    working_days: "",
+    holidays_days: "",
+    vacation_days: "",
+    sick_days: "",
+    focus_factor: "",
+    sprint_days: "",
+    overhead_days_per_sprint: "",
+  });
+
+  assert.equal(updated.calendar_year, 2026);
+  assert.equal(updated.quarter_index, 2);
+});
+
+test("validateInputPayload returns invalid with no error for empty input", () => {
+  const result = validateInputPayload("");
+  assert.equal(result.valid, false);
+  assert.equal(result.error, null);
+});
+
+test("validateInputPayload returns invalid with error for malformed JSON", () => {
+  const result = validateInputPayload("{bad json}");
+  assert.equal(result.valid, false);
+  assert.ok(result.error.startsWith("Invalid JSON:"));
+});
+
+test("validateInputPayload returns invalid with error for JSON array", () => {
+  const result = validateInputPayload("[1,2,3]");
+  assert.equal(result.valid, false);
+  assert.ok(result.error.includes("array"));
+});
+
+test("validateInputPayload returns valid for a well-formed JSON object", () => {
+  const result = validateInputPayload(JSON.stringify({planning_horizon: "quarter", roadmap: {features: []}}));
+  assert.equal(result.valid, true);
+  assert.equal(result.error, null);
 });
 
 test("getUtilizationStatus matches planner target semantics", () => {
@@ -278,4 +428,78 @@ test("buildFunctionAnalysisModel falls back to top-level fields when selected_pl
   assert.equal(devopsRow.capacity, 20);
   assert.equal(devopsRow.demand, 18);
   assert.equal(devopsRow.utilization, 0.9);
+});
+
+test("readEditableFieldsFromPayload reads planning_mode and all period selectors from payload", () => {
+  const fields = readEditableFieldsFromPayload({
+    planning_mode: "planning_schedule",
+    planning_horizon: "quarter",
+    calendar_year: 2026,
+    half_year_index: 1,
+    quarter_index: 2,
+    month_index: 4,
+    start_date: "2026-04-01",
+    end_date: "2026-04-14",
+  });
+
+  assert.equal(fields.planning_mode, "planning_schedule");
+  assert.equal(fields.calendar_year, 2026);
+  assert.equal(fields.half_year_index, 1);
+  assert.equal(fields.quarter_index, 2);
+  assert.equal(fields.month_index, 4);
+  assert.equal(fields.start_date, "2026-04-01");
+  assert.equal(fields.end_date, "2026-04-14");
+});
+
+test("applyEditableFieldsToPayload propagates planning_mode when switching modes", () => {
+  const original = {
+    planning_mode: "capacity_check",
+    planning_horizon: "quarter",
+    calendar_year: 2026,
+    quarter_index: 1,
+    roadmap: {features: []},
+  };
+
+  const updated = applyEditableFieldsToPayload(original, {
+    planning_mode: "planning_schedule",
+    planning_horizon: "quarter",
+    working_days: "",
+    holidays_days: "",
+    vacation_days: "",
+    sick_days: "",
+    focus_factor: "",
+    sprint_days: "",
+    overhead_days_per_sprint: "",
+  });
+
+  assert.equal(updated.planning_mode, "planning_schedule");
+});
+
+test("applyEditableFieldsToPayload uses form-provided quarter_index instead of inferring it", () => {
+  const original = {
+    planning_horizon: "quarter",
+    calendar_year: 2026,
+    quarter_index: 1,
+    month_index: 2,
+    roadmap: {features: []},
+  };
+
+  // Form explicitly selects Q3, overriding the Q1 in the original payload
+  const updated = applyEditableFieldsToPayload(original, {
+    planning_horizon: "quarter",
+    calendar_year: "2026",
+    quarter_index: "3",
+    working_days: "",
+    holidays_days: "",
+    vacation_days: "",
+    sick_days: "",
+    focus_factor: "",
+    sprint_days: "",
+    overhead_days_per_sprint: "",
+  });
+
+  assert.equal(updated.quarter_index, 3);
+  assert.equal(updated.calendar_year, 2026);
+  // month_index not present for quarter horizon
+  assert.equal(updated.month_index, undefined);
 });

--- a/ui/app.js
+++ b/ui/app.js
@@ -1,6 +1,13 @@
 export function readEditableFieldsFromPayload(data) {
   return {
+    planning_mode: data.planning_mode ?? "",
     planning_horizon: data.planning_horizon ?? "",
+    calendar_year: data.calendar_year ?? "",
+    half_year_index: data.half_year_index ?? "",
+    quarter_index: data.quarter_index ?? "",
+    month_index: data.month_index ?? "",
+    start_date: data.start_date ?? "",
+    end_date: data.end_date ?? "",
     working_days: data.working_days,
     holidays_days: data.holidays_days,
     vacation_days: data.vacation_days,
@@ -9,6 +16,24 @@ export function readEditableFieldsFromPayload(data) {
     sprint_days: data.sprint_days,
     overhead_days_per_sprint: data.overhead_days_per_sprint,
   };
+}
+
+export function validateInputPayload(jsonText) {
+  const text = typeof jsonText === "string" ? jsonText.trim() : "";
+  if (!text) {
+    return {valid: false, error: null};
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch (e) {
+    return {valid: false, error: "Invalid JSON: " + e.message};
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    const kind = Array.isArray(parsed) ? "array" : typeof parsed;
+    return {valid: false, error: "Input must be a JSON object, not " + kind};
+  }
+  return {valid: true, error: null};
 }
 
 export function applyEditableFieldsToPayload(data, rawFieldValues) {
@@ -23,9 +48,15 @@ export function applyEditableFieldsToPayload(data, rawFieldValues) {
     "overhead_days_per_sprint",
   ];
 
+  if (rawFieldValues.planning_mode !== undefined && rawFieldValues.planning_mode !== "") {
+    next.planning_mode = rawFieldValues.planning_mode;
+  }
+
   const nextPlanningHorizon = rawFieldValues.planning_horizon;
   next.planning_horizon = nextPlanningHorizon;
-  normalizePeriodSelectors(next, nextPlanningHorizon, data);
+
+  normalizePeriodSelectors(next, nextPlanningHorizon, buildPeriodSource(data, rawFieldValues));
+
   for (const field of fields) {
     const value = parseNumber(rawFieldValues[field]);
     if (value !== undefined) {
@@ -125,6 +156,7 @@ export function buildSummaryModel(result) {
   }
 
   return {
+    planningMode,
     bannerClass,
     bannerText,
     capacityDevDays: result.capacity_dev_days,
@@ -169,6 +201,24 @@ export function buildFunctionAnalysisModel(result) {
   };
 }
 
+export function buildPeriodSource(data, rawFieldValues) {
+  const calendarYear = parseFormInteger(rawFieldValues.calendar_year) ?? data.calendar_year;
+  const halfYearIndex = parseFormInteger(rawFieldValues.half_year_index) ?? data.half_year_index;
+  const quarterIndex = parseFormInteger(rawFieldValues.quarter_index) ?? data.quarter_index;
+  const monthIndex = parseFormInteger(rawFieldValues.month_index) ?? data.month_index;
+  const startDate = isValidIsoDateString(rawFieldValues.start_date) ? rawFieldValues.start_date : data.start_date;
+  const endDate = isValidIsoDateString(rawFieldValues.end_date) ? rawFieldValues.end_date : data.end_date;
+  return {
+    ...data,
+    calendar_year: calendarYear,
+    half_year_index: halfYearIndex,
+    quarter_index: quarterIndex,
+    month_index: monthIndex,
+    start_date: startDate,
+    end_date: endDate,
+  };
+}
+
 function parseNumber(value) {
   const number = Number.parseFloat(value);
   return Number.isNaN(number) ? undefined : number;
@@ -183,29 +233,46 @@ function normalizePeriodSelectors(payload, planningHorizon, sourcePayload = payl
   delete payload.end_date;
 
   const inferred = inferPeriodSelectors(sourcePayload);
+  const calendarYear = inferred.calendar_year;
+  const halfYearIndex = inferred.half_year_index;
+  const quarterIndex = inferred.quarter_index;
+  const monthIndex = inferred.month_index;
+  const startDate = inferred.start_date;
+  const endDate = inferred.end_date;
+
   if (planningHorizon === "year") {
-    payload.calendar_year = inferred.calendar_year;
+    payload.calendar_year = calendarYear;
     return;
   }
   if (planningHorizon === "half_year") {
-    payload.calendar_year = inferred.calendar_year;
-    payload.half_year_index = inferred.half_year_index;
+    payload.calendar_year = calendarYear;
+    payload.half_year_index = halfYearIndex;
     return;
   }
   if (planningHorizon === "quarter") {
-    payload.calendar_year = inferred.calendar_year;
-    payload.quarter_index = inferred.quarter_index;
+    payload.calendar_year = calendarYear;
+    payload.quarter_index = quarterIndex;
     return;
   }
   if (planningHorizon === "month") {
-    payload.calendar_year = inferred.calendar_year;
-    payload.month_index = inferred.month_index;
+    payload.calendar_year = calendarYear;
+    payload.month_index = monthIndex;
     return;
   }
   if (planningHorizon === "sprint") {
-    payload.start_date = inferred.start_date;
-    payload.end_date = inferred.end_date;
+    payload.start_date = startDate;
+    payload.end_date = endDate;
   }
+}
+
+function parseFormInteger(value) {
+  if (value == null || value === "") return undefined;
+  const n = Number.parseInt(String(value), 10);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function isValidIsoDateString(value) {
+  return typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value) && parseIsoDate(value) !== undefined;
 }
 
 function inferPeriodSelectors(payload) {

--- a/ui/index.html
+++ b/ui/index.html
@@ -255,6 +255,47 @@ select.example-select {
   margin-bottom: 10px;
 }
 .error-bar.visible { display: block; }
+.validation-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+  padding: 9px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: #f8fafc;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+}
+.validation-state::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: currentColor;
+}
+.validation-state[data-state="draft_loaded"] {
+  background: #f8fafc;
+  color: #64748b;
+}
+.validation-state[data-state="input_invalid"],
+.validation-state[data-state="run_error"] {
+  background: var(--red-bg);
+  border-color: #fecaca;
+  color: var(--red);
+}
+.validation-state[data-state="ready_to_run"],
+.validation-state[data-state="result_ready"] {
+  background: var(--green-bg);
+  border-color: #bbf7d0;
+  color: var(--green);
+}
+.validation-state[data-state="running"] {
+  background: var(--accent-light);
+  border-color: #bfdbfe;
+  color: var(--accent);
+}
 /* No-results placeholder */
 .no-results-placeholder {
   display: flex;
@@ -779,9 +820,17 @@ details[open] summary::before { content: "\25BC\00a0"; }
           </div>
 
           <div id="form-tab" class="tab-content">
+            <div id="form-json-state" class="validation-state" data-state="draft_loaded">Paste valid JSON to enable structured editing.</div>
             <div class="structured-editor">
-              <div class="section-label">Planning Period</div>
+              <div class="section-label">Mode &amp; Period</div>
               <div class="field-grid">
+                <div class="field-group">
+                  <label>Planning Mode</label>
+                  <select id="f-mode">
+                    <option value="capacity_check">Capacity Check</option>
+                    <option value="planning_schedule">Planning Schedule</option>
+                  </select>
+                </div>
                 <div class="field-group">
                   <label>Planning Horizon</label>
                   <select id="f-horizon">
@@ -791,6 +840,51 @@ details[open] summary::before { content: "\25BC\00a0"; }
                     <option value="half_year">Half Year</option>
                     <option value="year">Year</option>
                   </select>
+                </div>
+                <div class="field-group" id="ps-calendar-year" style="display:none">
+                  <label>Calendar Year</label>
+                  <input type="number" id="f-calendar-year" min="2020" max="2035" step="1">
+                </div>
+                <div class="field-group" id="ps-half-year-index" style="display:none">
+                  <label>Half Year</label>
+                  <select id="f-half-year-index">
+                    <option value="1">H1</option>
+                    <option value="2">H2</option>
+                  </select>
+                </div>
+                <div class="field-group" id="ps-quarter-index" style="display:none">
+                  <label>Quarter</label>
+                  <select id="f-quarter-index">
+                    <option value="1">Q1</option>
+                    <option value="2">Q2</option>
+                    <option value="3">Q3</option>
+                    <option value="4">Q4</option>
+                  </select>
+                </div>
+                <div class="field-group" id="ps-month-index" style="display:none">
+                  <label>Month</label>
+                  <select id="f-month-index">
+                    <option value="1">January</option>
+                    <option value="2">February</option>
+                    <option value="3">March</option>
+                    <option value="4">April</option>
+                    <option value="5">May</option>
+                    <option value="6">June</option>
+                    <option value="7">July</option>
+                    <option value="8">August</option>
+                    <option value="9">September</option>
+                    <option value="10">October</option>
+                    <option value="11">November</option>
+                    <option value="12">December</option>
+                  </select>
+                </div>
+                <div class="field-group" id="ps-start-date" style="display:none">
+                  <label>Start Date</label>
+                  <input type="date" id="f-start-date">
+                </div>
+                <div class="field-group" id="ps-end-date" style="display:none">
+                  <label>End Date</label>
+                  <input type="date" id="f-end-date">
                 </div>
               </div>
 
@@ -939,6 +1033,7 @@ import {
   buildSummaryModel,
   getUtilizationStatus,
   readEditableFieldsFromPayload,
+  validateInputPayload,
 } from "/assets/app.js";
 
 (function() {
@@ -961,7 +1056,14 @@ import {
 
   // Form fields
   const formFields = {
+    mode: document.getElementById("f-mode"),
     horizon: document.getElementById("f-horizon"),
+    calendarYear: document.getElementById("f-calendar-year"),
+    halfYearIndex: document.getElementById("f-half-year-index"),
+    quarterIndex: document.getElementById("f-quarter-index"),
+    monthIndex: document.getElementById("f-month-index"),
+    startDate: document.getElementById("f-start-date"),
+    endDate: document.getElementById("f-end-date"),
     workingDays: document.getElementById("f-working-days"),
     holidays: document.getElementById("f-holidays"),
     vacation: document.getElementById("f-vacation"),
@@ -988,6 +1090,7 @@ import {
     if (this.value) {
       jsonInput.value = this.value;
       syncFormFromJson();
+      refreshValidationState();
     }
     this.selectedIndex = 0;
   });
@@ -1015,6 +1118,7 @@ import {
     reader.onload = function(e) {
       jsonInput.value = e.target.result;
       syncFormFromJson();
+      refreshValidationState();
     };
     reader.readAsText(file);
   }
@@ -1033,18 +1137,61 @@ import {
     });
   });
 
+  // --- Validation state ---
+  const formJsonState = document.getElementById("form-json-state");
+
+  function setFormState(state, message) {
+    formJsonState.dataset.state = state;
+    formJsonState.textContent = message;
+  }
+
+  function refreshValidationState() {
+    const result = validateInputPayload(jsonInput.value);
+    if (result.error) {
+      showInputError(result.error);
+      setFormState("input_invalid", "Input invalid");
+    } else if (!result.valid) {
+      hideInputError();
+      setFormState("draft_loaded", "Paste valid JSON to enable structured editing.");
+    } else {
+      hideInputError();
+      setFormState("ready_to_run", "Ready to run");
+    }
+    runBtn.disabled = !result.valid;
+  }
+
+  // --- Period selector visibility ---
+  function updatePeriodSelectorVisibility() {
+    const h = formFields.horizon.value;
+    const showYear = h === "year" || h === "half_year" || h === "quarter" || h === "month";
+    document.getElementById("ps-calendar-year").style.display = showYear ? "" : "none";
+    document.getElementById("ps-half-year-index").style.display = h === "half_year" ? "" : "none";
+    document.getElementById("ps-quarter-index").style.display = h === "quarter" ? "" : "none";
+    document.getElementById("ps-month-index").style.display = h === "month" ? "" : "none";
+    document.getElementById("ps-start-date").style.display = h === "sprint" ? "" : "none";
+    document.getElementById("ps-end-date").style.display = h === "sprint" ? "" : "none";
+  }
+
   // --- Form <-> JSON sync ---
   function syncFormFromJson() {
     try {
       const editableFields = readEditableFieldsFromPayload(JSON.parse(jsonInput.value));
-      if (editableFields.planning_horizon) formFields.horizon.value = editableFields.planning_horizon;
-      if (editableFields.working_days != null) formFields.workingDays.value = editableFields.working_days;
-      if (editableFields.holidays_days != null) formFields.holidays.value = editableFields.holidays_days;
-      if (editableFields.vacation_days != null) formFields.vacation.value = editableFields.vacation_days;
-      if (editableFields.sick_days != null) formFields.sick.value = editableFields.sick_days;
-      if (editableFields.focus_factor != null) formFields.focus.value = editableFields.focus_factor;
-      if (editableFields.sprint_days != null) formFields.sprintDays.value = editableFields.sprint_days;
-      if (editableFields.overhead_days_per_sprint != null) formFields.overhead.value = editableFields.overhead_days_per_sprint;
+      formFields.mode.value = editableFields.planning_mode || "capacity_check";
+      formFields.horizon.value = editableFields.planning_horizon || "quarter";
+      formFields.calendarYear.value = editableFields.calendar_year === "" ? "" : editableFields.calendar_year;
+      formFields.halfYearIndex.value = editableFields.half_year_index === "" ? "1" : String(editableFields.half_year_index);
+      formFields.quarterIndex.value = editableFields.quarter_index === "" ? "1" : String(editableFields.quarter_index);
+      formFields.monthIndex.value = editableFields.month_index === "" ? "1" : String(editableFields.month_index);
+      formFields.startDate.value = editableFields.start_date || "";
+      formFields.endDate.value = editableFields.end_date || "";
+      formFields.workingDays.value = editableFields.working_days ?? "";
+      formFields.holidays.value = editableFields.holidays_days ?? "";
+      formFields.vacation.value = editableFields.vacation_days ?? "";
+      formFields.sick.value = editableFields.sick_days ?? "";
+      formFields.focus.value = editableFields.focus_factor ?? "";
+      formFields.sprintDays.value = editableFields.sprint_days ?? "";
+      formFields.overhead.value = editableFields.overhead_days_per_sprint ?? "";
+      updatePeriodSelectorVisibility();
     } catch(e) { /* ignore parse errors during typing */ }
   }
 
@@ -1052,7 +1199,14 @@ import {
     try {
       const data = JSON.parse(jsonInput.value);
       const nextData = applyEditableFieldsToPayload(data, {
+        planning_mode: formFields.mode.value,
         planning_horizon: formFields.horizon.value,
+        calendar_year: formFields.calendarYear.value,
+        half_year_index: formFields.halfYearIndex.value,
+        quarter_index: formFields.quarterIndex.value,
+        month_index: formFields.monthIndex.value,
+        start_date: formFields.startDate.value,
+        end_date: formFields.endDate.value,
         working_days: formFields.workingDays.value,
         holidays_days: formFields.holidays.value,
         vacation_days: formFields.vacation.value,
@@ -1062,14 +1216,28 @@ import {
         overhead_days_per_sprint: formFields.overhead.value,
       });
       jsonInput.value = JSON.stringify(nextData, null, 2);
+      refreshValidationState();
     } catch(e) { /* ignore if JSON is invalid */ }
   }
 
-  Object.values(formFields).forEach(field => {
-    field.addEventListener("change", syncJsonFromForm);
-    field.addEventListener("input", syncJsonFromForm);
+  formFields.horizon.addEventListener("change", function() {
+    updatePeriodSelectorVisibility();
+    syncJsonFromForm();
   });
-  jsonInput.addEventListener("input", syncFormFromJson);
+  Object.values(formFields).forEach(field => {
+    if (field !== formFields.horizon) {
+      field.addEventListener("change", syncJsonFromForm);
+      field.addEventListener("input", syncJsonFromForm);
+    }
+  });
+  jsonInput.addEventListener("input", function() {
+    syncFormFromJson();
+    refreshValidationState();
+  });
+
+  // Initialize
+  updatePeriodSelectorVisibility();
+  refreshValidationState();
 
   // --- Run planner ---
   runBtn.addEventListener("click", runPlanner);
@@ -1087,6 +1255,7 @@ import {
 
     runBtn.disabled = true;
     runBtn.innerHTML = '<span class="spinner"></span>Running...';
+    setFormState("running", "Running planner");
 
     try {
       const resp = await fetch("/api/plan", {
@@ -1098,6 +1267,7 @@ import {
       if (!resp.ok) {
         showRunError(data.error || "Planner error: server returned " + resp.status);
         showDecisionWorkspace(false);
+        setFormState("run_error", "Run error");
         return;
       }
       lastResult = data;
@@ -1106,12 +1276,14 @@ import {
       outputJson.textContent = JSON.stringify(data, null, 2);
       renderResults(data);
       showDecisionWorkspace(true);
+      setFormState("result_ready", "Result ready");
       document.getElementById("summary-panel").scrollIntoView({behavior: "smooth", block: "start"});
     } catch(e) {
       showRunError("Network error: " + e.message);
       showDecisionWorkspace(false);
+      setFormState("run_error", "Run error");
     } finally {
-      runBtn.disabled = false;
+      runBtn.disabled = !validateInputPayload(jsonInput.value).valid;
       runBtn.textContent = "Run Planner";
     }
   }


### PR DESCRIPTION
## Summary
- add structured editor controls for planning mode and period selectors
- surface explicit editor state for invalid, ready, running, result, and run-error flows
- keep raw JSON as the source of truth while letting form-provided period values win when appropriate

## Verification
- node --test tests/ui_logic.test.mjs
- PYTHONPATH=src .venv/bin/python -m unittest tests.test_ui_spec

## Notes
- Claude Code CLI was used for the implementation pass on this branch, then the diff was reviewed and tightened locally before shipping.

Closes #78