### PR TITLE
Fix UI period inference and add Codex review gate

### DIFF
--- a/.codex/skills/github-shipping/SKILL.md
+++ b/.codex/skills/github-shipping/SKILL.md
@@ -23,6 +23,8 @@ description: "Use when the user wants to finish, ship, push, merge, or complete 
 5. After CI turns green, do one final review sweep across those same three surfaces.
 6. Do not treat a PR as ready just because CI is green.
 7. If there are actionable review findings, address them or explicitly decide to defer them before merge.
+8. In this repo, prefer `scripts/pr_ready_check.sh <pr-number>` for the final merge-readiness sweep.
+9. Respect the `codex-review-gate` required check unless the repo owner explicitly chooses the `codex-review-skipped` override label.
 
 ## What this skill adds
 
@@ -48,5 +50,7 @@ For GitHub PRs in this repo, check:
 3. Inline review comments
    - example: `gh api repos/<owner>/<repo>/pulls/<number>/comments`
 4. Re-run the three review checks once after CI is green and immediately before merge
+5. Prefer `scripts/pr_ready_check.sh <number>` as the final single-command summary before merge
+6. If `codex-review-gate` is failing, wait for the Codex review to arrive or explicitly apply the `codex-review-skipped` label before merge
 
 If any inline or review comments contain actionable findings, handle them before merge or call them out explicitly to the user.

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -1,0 +1,73 @@
+name: Codex Review Gate
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - converted_to_draft
+      - labeled
+      - unlabeled
+  pull_request_review:
+    types:
+      - submitted
+      - dismissed
+
+jobs:
+  codex-review-gate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Check Codex review receipt
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const reviewAuthorLogins = new Set([
+              "chatgpt-codex-connector",
+              "chatgpt-codex-connector[bot]",
+            ]);
+            const overrideLabel = "codex-review-skipped";
+            const pr = context.payload.pull_request;
+            if (!pr) {
+              core.setFailed("No pull request payload available for Codex review gate.");
+              return;
+            }
+
+            if (pr.draft) {
+              core.notice(`PR #${pr.number} is still a draft; Codex review gate is waiting for ready-for-review.`);
+              return;
+            }
+
+            const labels = (pr.labels || []).map((label) => label.name);
+            if (labels.includes(overrideLabel)) {
+              core.notice(`Override label '${overrideLabel}' applied; Codex review gate passed.`);
+              return;
+            }
+
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+
+            const codexReviews = reviews.filter((review) => {
+              const login = review.user?.login || review.author_association || "";
+              return reviewAuthorLogins.has(login);
+            });
+
+            if (codexReviews.length > 0) {
+              const latest = codexReviews[codexReviews.length - 1];
+              core.notice(
+                `Codex review received from ${latest.user?.login || "chatgpt-codex-connector"} on commit ${latest.commit_id || "unknown"}.`
+              );
+              return;
+            }
+
+            core.setFailed(
+              `No Codex review received yet. Wait for chatgpt-codex-connector review or apply the '${overrideLabel}' label to bypass this gate.`
+            );

--- a/scripts/pr_ready_check.sh
+++ b/scripts/pr_ready_check.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: scripts/pr_ready_check.sh <pr-number> [owner/repo]" >&2
+  exit 2
+fi
+
+PR_NUMBER="$1"
+REPO="${2:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
+
+PR_JSON="$(gh pr view -R "$REPO" "$PR_NUMBER" --json state,mergeStateStatus,reviews,comments,statusCheckRollup,labels,url)"
+INLINE_JSON="$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments")"
+
+python3 - "$PR_NUMBER" "$PR_JSON" "$INLINE_JSON" <<'PY'
+import json
+import sys
+
+pr_number = sys.argv[1]
+pr = json.loads(sys.argv[2])
+inline_comments = json.loads(sys.argv[3])
+
+labels = [label["name"] for label in pr.get("labels", [])]
+reviewers = [review.get("author", {}).get("login", "") for review in pr.get("reviews", [])]
+codex_review_present = any(
+    login in {"chatgpt-codex-connector", "chatgpt-codex-connector[bot]"}
+    for login in reviewers
+)
+override_present = "codex-review-skipped" in labels
+
+check_rollup = pr.get("statusCheckRollup", [])
+blocking_checks = []
+pending_checks = []
+for check in check_rollup:
+    status = check.get("status")
+    conclusion = check.get("conclusion")
+    name = check.get("name", "unknown")
+    if status != "COMPLETED":
+      pending_checks.append(name)
+    elif conclusion != "SUCCESS":
+      blocking_checks.append(f"{name} ({conclusion})")
+
+print(f"PR #{pr_number}: {pr.get('url')}")
+print(f"State: {pr.get('state')}  Merge status: {pr.get('mergeStateStatus')}")
+print(f"Checks: {len(check_rollup)} total")
+print(f"Top-level reviews: {len(pr.get('reviews', []))}")
+print(f"Top-level comments: {len(pr.get('comments', []))}")
+print(f"Inline review comments: {len(inline_comments)}")
+print(f"Codex review present: {'yes' if codex_review_present else 'no'}")
+print(f"Override label present: {'yes' if override_present else 'no'}")
+
+if blocking_checks:
+    print("Blocking checks:")
+    for check in blocking_checks:
+        print(f"- {check}")
+
+if pending_checks:
+    print("Pending checks:")
+    for check in pending_checks:
+        print(f"- {check}")
+
+if inline_comments:
+    print("Inline comment URLs:")
+    for comment in inline_comments:
+        print(f"- {comment.get('html_url')}")
+
+blocking = False
+
+if pr.get("state") != "OPEN":
+    print("Not merge-ready: PR is not open.")
+    blocking = True
+
+if blocking_checks or pending_checks:
+    print("Not merge-ready: checks are not all green yet.")
+    blocking = True
+
+if inline_comments:
+    print("Not merge-ready: unresolved inline review comments are present.")
+    blocking = True
+
+if not codex_review_present and not override_present:
+    print("Not merge-ready: Codex review has not been received and no override label is present.")
+    blocking = True
+
+sys.exit(1 if blocking else 0)
+PY

--- a/tests/ui_logic.test.mjs
+++ b/tests/ui_logic.test.mjs
@@ -6,6 +6,7 @@ import {
   buildFunctionAnalysisModel,
   buildPeriodSource,
   buildPlanComparison,
+  buildStructuredFormState,
   buildSummaryModel,
   getUtilizationStatus,
   readEditableFieldsFromPayload,
@@ -58,6 +59,26 @@ test("readEditableFieldsFromPayload includes sprint period selectors when presen
   assert.equal(editableFields.start_date, "2026-06-01");
   assert.equal(editableFields.end_date, "2026-06-14");
   assert.equal(editableFields.calendar_year, "");
+});
+
+test("buildStructuredFormState keeps absent period selectors blank", () => {
+  const formState = buildStructuredFormState({
+    planning_mode: "capacity_check",
+    planning_horizon: "quarter",
+    calendar_year: 2026,
+    half_year_index: "",
+    quarter_index: 3,
+    month_index: "",
+    start_date: "",
+    end_date: "",
+  });
+
+  assert.equal(formState.planning_mode, "capacity_check");
+  assert.equal(formState.planning_horizon, "quarter");
+  assert.equal(formState.calendar_year, "2026");
+  assert.equal(formState.half_year_index, "");
+  assert.equal(formState.quarter_index, "3");
+  assert.equal(formState.month_index, "");
 });
 
 test("applyEditableFieldsToPayload preserves unrelated pasted JSON values", () => {
@@ -256,6 +277,31 @@ test("applyEditableFieldsToPayload ignores empty-string period selector form val
 
   assert.equal(updated.calendar_year, 2026);
   assert.equal(updated.quarter_index, 2);
+});
+
+test("applyEditableFieldsToPayload infers month from existing quarter when month selector is blank", () => {
+  const original = {
+    planning_horizon: "quarter",
+    calendar_year: 2026,
+    quarter_index: 3,
+    roadmap: {features: []},
+  };
+
+  const updated = applyEditableFieldsToPayload(original, {
+    planning_horizon: "month",
+    calendar_year: "2026",
+    month_index: "",
+    working_days: "",
+    holidays_days: "",
+    vacation_days: "",
+    sick_days: "",
+    focus_factor: "",
+    sprint_days: "",
+    overhead_days_per_sprint: "",
+  });
+
+  assert.equal(updated.calendar_year, 2026);
+  assert.equal(updated.month_index, 7);
 });
 
 test("validateInputPayload returns invalid with no error for empty input", () => {

--- a/ui/app.js
+++ b/ui/app.js
@@ -18,6 +18,26 @@ export function readEditableFieldsFromPayload(data) {
   };
 }
 
+export function buildStructuredFormState(editableFields) {
+  return {
+    planning_mode: editableFields.planning_mode || "capacity_check",
+    planning_horizon: editableFields.planning_horizon || "quarter",
+    calendar_year: editableFields.calendar_year === "" ? "" : String(editableFields.calendar_year),
+    half_year_index: editableFields.half_year_index === "" ? "" : String(editableFields.half_year_index),
+    quarter_index: editableFields.quarter_index === "" ? "" : String(editableFields.quarter_index),
+    month_index: editableFields.month_index === "" ? "" : String(editableFields.month_index),
+    start_date: editableFields.start_date || "",
+    end_date: editableFields.end_date || "",
+    working_days: editableFields.working_days ?? "",
+    holidays_days: editableFields.holidays_days ?? "",
+    vacation_days: editableFields.vacation_days ?? "",
+    sick_days: editableFields.sick_days ?? "",
+    focus_factor: editableFields.focus_factor ?? "",
+    sprint_days: editableFields.sprint_days ?? "",
+    overhead_days_per_sprint: editableFields.overhead_days_per_sprint ?? "",
+  };
+}
+
 export function validateInputPayload(jsonText) {
   const text = typeof jsonText === "string" ? jsonText.trim() : "";
   if (!text) {

--- a/ui/index.html
+++ b/ui/index.html
@@ -848,6 +848,7 @@ details[open] summary::before { content: "\25BC\00a0"; }
                 <div class="field-group" id="ps-half-year-index" style="display:none">
                   <label>Half Year</label>
                   <select id="f-half-year-index">
+                    <option value="">Auto</option>
                     <option value="1">H1</option>
                     <option value="2">H2</option>
                   </select>
@@ -855,6 +856,7 @@ details[open] summary::before { content: "\25BC\00a0"; }
                 <div class="field-group" id="ps-quarter-index" style="display:none">
                   <label>Quarter</label>
                   <select id="f-quarter-index">
+                    <option value="">Auto</option>
                     <option value="1">Q1</option>
                     <option value="2">Q2</option>
                     <option value="3">Q3</option>
@@ -864,6 +866,7 @@ details[open] summary::before { content: "\25BC\00a0"; }
                 <div class="field-group" id="ps-month-index" style="display:none">
                   <label>Month</label>
                   <select id="f-month-index">
+                    <option value="">Auto</option>
                     <option value="1">January</option>
                     <option value="2">February</option>
                     <option value="3">March</option>
@@ -1030,6 +1033,7 @@ import {
   applyEditableFieldsToPayload,
   buildFunctionAnalysisModel,
   buildPlanComparison,
+  buildStructuredFormState,
   buildSummaryModel,
   getUtilizationStatus,
   readEditableFieldsFromPayload,
@@ -1176,21 +1180,22 @@ import {
   function syncFormFromJson() {
     try {
       const editableFields = readEditableFieldsFromPayload(JSON.parse(jsonInput.value));
-      formFields.mode.value = editableFields.planning_mode || "capacity_check";
-      formFields.horizon.value = editableFields.planning_horizon || "quarter";
-      formFields.calendarYear.value = editableFields.calendar_year === "" ? "" : editableFields.calendar_year;
-      formFields.halfYearIndex.value = editableFields.half_year_index === "" ? "1" : String(editableFields.half_year_index);
-      formFields.quarterIndex.value = editableFields.quarter_index === "" ? "1" : String(editableFields.quarter_index);
-      formFields.monthIndex.value = editableFields.month_index === "" ? "1" : String(editableFields.month_index);
-      formFields.startDate.value = editableFields.start_date || "";
-      formFields.endDate.value = editableFields.end_date || "";
-      formFields.workingDays.value = editableFields.working_days ?? "";
-      formFields.holidays.value = editableFields.holidays_days ?? "";
-      formFields.vacation.value = editableFields.vacation_days ?? "";
-      formFields.sick.value = editableFields.sick_days ?? "";
-      formFields.focus.value = editableFields.focus_factor ?? "";
-      formFields.sprintDays.value = editableFields.sprint_days ?? "";
-      formFields.overhead.value = editableFields.overhead_days_per_sprint ?? "";
+      const formState = buildStructuredFormState(editableFields);
+      formFields.mode.value = formState.planning_mode;
+      formFields.horizon.value = formState.planning_horizon;
+      formFields.calendarYear.value = formState.calendar_year;
+      formFields.halfYearIndex.value = formState.half_year_index;
+      formFields.quarterIndex.value = formState.quarter_index;
+      formFields.monthIndex.value = formState.month_index;
+      formFields.startDate.value = formState.start_date;
+      formFields.endDate.value = formState.end_date;
+      formFields.workingDays.value = formState.working_days;
+      formFields.holidays.value = formState.holidays_days;
+      formFields.vacation.value = formState.vacation_days;
+      formFields.sick.value = formState.sick_days;
+      formFields.focus.value = formState.focus_factor;
+      formFields.sprintDays.value = formState.sprint_days;
+      formFields.overhead.value = formState.overhead_days_per_sprint;
       updatePeriodSelectorVisibility();
     } catch(e) { /* ignore parse errors during typing */ }
   }


### PR DESCRIPTION
## Summary
- fix the #85 structured-editor regression so hidden period selectors no longer default to unintended explicit values
- add a Codex review gate workflow with an override-label escape hatch
- add a PR readiness helper script and wire it into the shipping skill

## Verification
- node --test tests/ui_logic.test.mjs
- PYTHONPATH=src .venv/bin/python -m unittest tests.test_ui_spec
- bash -n scripts/pr_ready_check.sh
- scripts/pr_ready_check.sh 85 lyudmylan/capacity-planning-tool

Closes #86
Closes #87