### PR TITLE
Implement mode-aware result surfaces

### DIFF
--- a/tests/ui_logic.test.mjs
+++ b/tests/ui_logic.test.mjs
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
   applyEditableFieldsToPayload,
   buildFunctionAnalysisModel,
+  buildModeAwareSummaryContext,
   buildPeriodSource,
   buildPlanComparison,
   buildStructuredFormState,
@@ -548,4 +549,162 @@ test("applyEditableFieldsToPayload uses form-provided quarter_index instead of i
   assert.equal(updated.calendar_year, 2026);
   // month_index not present for quarter horizon
   assert.equal(updated.month_index, undefined);
+});
+
+// --- buildModeAwareSummaryContext ---
+
+test("buildModeAwareSummaryContext returns baseline_vs_selected framing for capacity_check", () => {
+  const ctx = buildModeAwareSummaryContext({
+    planning_mode: "capacity_check",
+    baseline_plan: {feasibility: false},
+    selected_plan: {feasibility: true},
+  });
+
+  assert.equal(ctx.planningMode, "capacity_check");
+  assert.equal(ctx.comparisonModel, "baseline_vs_selected");
+  assert.equal(ctx.showBaselineComparison, true);
+  assert.ok(ctx.primaryQuestion.length > 0);
+});
+
+test("buildModeAwareSummaryContext returns selected_plan_primary framing for planning_schedule", () => {
+  const ctx = buildModeAwareSummaryContext({
+    planning_mode: "planning_schedule",
+    dependency_rules_pass: true,
+    selected_plan: {feasibility: true},
+  });
+
+  assert.equal(ctx.planningMode, "planning_schedule");
+  assert.equal(ctx.comparisonModel, "selected_plan_primary");
+  assert.equal(ctx.showBaselineComparison, false);
+  assert.ok(ctx.primaryQuestion.length > 0);
+});
+
+test("buildModeAwareSummaryContext showBaselineComparison is false when no baseline_plan", () => {
+  const ctx = buildModeAwareSummaryContext({
+    planning_mode: "capacity_check",
+  });
+
+  assert.equal(ctx.comparisonModel, "baseline_vs_selected");
+  assert.equal(ctx.showBaselineComparison, false);
+});
+
+test("buildModeAwareSummaryContext capacity_check and planning_schedule have distinct primary questions", () => {
+  const ccCtx = buildModeAwareSummaryContext({planning_mode: "capacity_check"});
+  const psCtx = buildModeAwareSummaryContext({planning_mode: "planning_schedule"});
+
+  assert.notEqual(ccCtx.primaryQuestion, psCtx.primaryQuestion);
+});
+
+// --- buildSummaryModel mode-aware fields ---
+
+test("buildSummaryModel returns dependencyRulesPass from top-level field for planning_schedule", () => {
+  const summary = buildSummaryModel({
+    planning_mode: "planning_schedule",
+    capacity_dev_days: 80,
+    feasibility: true,
+    dependency_rules_pass: true,
+    delivered_features: [],
+    deferred_features: [],
+    dropped_features: [],
+  });
+
+  assert.equal(summary.dependencyRulesPass, true);
+});
+
+test("buildSummaryModel returns dependencyRulesPass false when dependency rules fail", () => {
+  const summary = buildSummaryModel({
+    planning_mode: "planning_schedule",
+    capacity_dev_days: 80,
+    feasibility: false,
+    dependency_rules_pass: false,
+    bottleneck_functions: [],
+    delivered_features: [],
+    deferred_features: [],
+    dropped_features: [],
+  });
+
+  assert.equal(summary.dependencyRulesPass, false);
+});
+
+test("buildSummaryModel returns dependencyRulesPass null when field is absent (capacity_check)", () => {
+  const summary = buildSummaryModel({
+    planning_mode: "capacity_check",
+    capacity_dev_days: 80,
+    baseline_plan: {feasibility: false},
+    selected_plan: {
+      feasibility: true,
+      delivered_features: [],
+      deferred_features: [],
+      dropped_features: [],
+    },
+  });
+
+  assert.equal(summary.dependencyRulesPass, null);
+});
+
+test("buildSummaryModel returns functionCapacityFit from selected_plan", () => {
+  const summary = buildSummaryModel({
+    planning_mode: "planning_schedule",
+    capacity_dev_days: 80,
+    selected_plan: {
+      feasibility: true,
+      function_capacity_fit: {eng: true, qa: false},
+      delivered_features: [],
+      deferred_features: [],
+      dropped_features: [],
+    },
+  });
+
+  assert.deepEqual(summary.functionCapacityFit, {eng: true, qa: false});
+});
+
+test("buildSummaryModel returns empty functionCapacityFit when absent", () => {
+  const summary = buildSummaryModel({
+    planning_mode: "capacity_check",
+    capacity_dev_days: 80,
+    selected_plan: {
+      feasibility: true,
+      delivered_features: [],
+      deferred_features: [],
+      dropped_features: [],
+    },
+  });
+
+  assert.deepEqual(summary.functionCapacityFit, {});
+});
+
+// --- buildFunctionAnalysisModel fits field ---
+
+test("buildFunctionAnalysisModel includes fits per row from function_capacity_fit", () => {
+  const model = buildFunctionAnalysisModel({
+    planning_mode: "planning_schedule",
+    capacity_by_function: {eng: 80, qa: 40},
+    demand_by_function: {eng: 72, qa: 44},
+    utilization_by_function: {eng: 0.9, qa: 1.1},
+    buffer_by_function: {eng: 8, qa: -4},
+    bottleneck_functions: ["qa"],
+    function_capacity_fit: {eng: true, qa: false},
+  });
+
+  const engRow = model.rows.find((r) => r.name === "eng");
+  const qaRow = model.rows.find((r) => r.name === "qa");
+
+  assert.equal(engRow.fits, true);
+  assert.equal(qaRow.fits, false);
+});
+
+test("buildFunctionAnalysisModel fits is null when function_capacity_fit is absent", () => {
+  const model = buildFunctionAnalysisModel({
+    planning_mode: "capacity_check",
+    selected_plan: {
+      capacity_by_function: {eng: 70},
+      demand_by_function: {eng: 60},
+      utilization_by_function: {eng: 0.86},
+      buffer_by_function: {eng: 10},
+      bottleneck_functions: [],
+    },
+  });
+
+  const engRow = model.rows.find((r) => r.name === "eng");
+  assert.equal(engRow.fits, null);
 });

--- a/ui/app.js
+++ b/ui/app.js
@@ -175,6 +175,13 @@ export function buildSummaryModel(result) {
     bannerText = "Selected plan is feasible";
   }
 
+  const dependencyRulesPass = "dependency_rules_pass" in result
+    ? result.dependency_rules_pass
+    : "dependency_rules_pass" in selectedPlan
+      ? selectedPlan.dependency_rules_pass
+      : null;
+  const functionCapacityFit = selectedPlan.function_capacity_fit ?? result.function_capacity_fit ?? {};
+
   return {
     planningMode,
     bannerClass,
@@ -187,6 +194,32 @@ export function buildSummaryModel(result) {
     deferredCount: deferredFeatures.length,
     droppedCount: droppedFeatures.length,
     selectedPlanFeasible: selectedPlan.feasibility,
+    dependencyRulesPass,
+    functionCapacityFit,
+  };
+}
+
+export function buildModeAwareSummaryContext(result) {
+  const baselinePlan = result.baseline_plan ?? null;
+  const selectedPlan = result.selected_plan ?? null;
+  const planningMode = result.planning_mode
+    ?? selectedPlan?.planning_mode
+    ?? baselinePlan?.planning_mode
+    ?? "capacity_check";
+
+  if (planningMode === "planning_schedule") {
+    return {
+      planningMode,
+      primaryQuestion: "Can this selected scope finish inside the horizon once dependency rules are applied?",
+      comparisonModel: "selected_plan_primary",
+      showBaselineComparison: false,
+    };
+  }
+  return {
+    planningMode,
+    primaryQuestion: "Can the current organization likely deliver this roadmap within the selected horizon?",
+    comparisonModel: "baseline_vs_selected",
+    showBaselineComparison: baselinePlan !== null,
   };
 }
 
@@ -197,6 +230,7 @@ export function buildFunctionAnalysisModel(result) {
   const utilizationByFunction = selectedPlan.utilization_by_function ?? {};
   const bufferByFunction = selectedPlan.buffer_by_function ?? {};
   const bottleneckFunctions = selectedPlan.bottleneck_functions ?? result.bottleneck_functions ?? [];
+  const functionCapacityFit = selectedPlan.function_capacity_fit ?? result.function_capacity_fit ?? {};
 
   const allFunctionNames = Array.from(new Set([
     ...Object.keys(capacityByFunction),
@@ -212,6 +246,7 @@ export function buildFunctionAnalysisModel(result) {
     utilization: utilizationByFunction[name] ?? null,
     buffer: bufferByFunction[name] ?? null,
     isBottleneck: bottleneckFunctions.includes(name),
+    fits: name in functionCapacityFit ? functionCapacityFit[name] : null,
   }));
 
   return {

--- a/ui/index.html
+++ b/ui/index.html
@@ -398,6 +398,19 @@ select.example-select {
 .metric-value.feasible { color: var(--green); }
 .metric-value.infeasible { color: var(--red); }
 .metric-value.warning { color: var(--amber); }
+/* Mode question */
+.mode-question {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin-bottom: 14px;
+  padding: 8px 12px;
+  background: var(--bg);
+  border-radius: 5px;
+  border-left: 3px solid var(--border);
+  line-height: 1.5;
+}
+.mode-question.capacity-check { border-left-color: var(--accent); }
+.mode-question.planning-schedule { border-left-color: var(--green); }
 /* Dependency status */
 .dep-status {
   display: flex;
@@ -959,6 +972,7 @@ details[open] summary::before { content: "\25BC\00a0"; }
           </div>
           <div class="panel-body">
             <div id="feasibility-banner" class="feasibility-banner"></div>
+            <div id="mode-question" class="mode-question" style="display:none"></div>
             <div class="summary-grid" id="summary-grid"></div>
             <div id="dep-status-section" style="margin-top:14px;display:none"></div>
             <div id="fn-fit-section" style="margin-top:14px;display:none"></div>
@@ -1032,6 +1046,7 @@ details[open] summary::before { content: "\25BC\00a0"; }
 import {
   applyEditableFieldsToPayload,
   buildFunctionAnalysisModel,
+  buildModeAwareSummaryContext,
   buildPlanComparison,
   buildStructuredFormState,
   buildSummaryModel,
@@ -1347,6 +1362,13 @@ import {
     banner.className = summary.bannerClass;
     banner.textContent = summary.bannerText;
 
+    // Mode-specific primary question
+    const modeCtx = buildModeAwareSummaryContext(data);
+    const modeQuestionEl = document.getElementById("mode-question");
+    modeQuestionEl.style.display = "";
+    modeQuestionEl.className = "mode-question " + (summary.planningMode === "planning_schedule" ? "planning-schedule" : "capacity-check");
+    modeQuestionEl.textContent = modeCtx.primaryQuestion;
+
     // Metrics grid
     const utilClass = getUtilizationStatus(summary.utilization);
     const grid = document.getElementById("summary-grid");
@@ -1369,9 +1391,9 @@ import {
       grid.appendChild(card);
     });
 
-    // Dependency rule status (planning_schedule)
+    // Dependency rule status (present only for planning_schedule results)
     const depSection = document.getElementById("dep-status-section");
-    if (summary.dependencyRulesPass !== null) {
+    if (summary.dependencyRulesPass !== null && summary.dependencyRulesPass !== undefined) {
       depSection.style.display = "";
       depSection.innerHTML = "";
       const depDiv = document.createElement("div");
@@ -1386,7 +1408,7 @@ import {
 
     // Function capacity fit chips
     const fnFitSection = document.getElementById("fn-fit-section");
-    const fitKeys = Object.keys(summary.functionCapacityFit);
+    const fitKeys = Object.keys(summary.functionCapacityFit ?? {});
     if (fitKeys.length > 0) {
       fnFitSection.style.display = "";
       fnFitSection.innerHTML = '<div class="fn-fit-label">Function Capacity Fit</div>';
@@ -1411,7 +1433,7 @@ import {
     body.innerHTML = "";
     const model = buildFunctionAnalysisModel(data);
 
-    if (!model || model.length === 0) {
+    if (!model || model.rows.length === 0) {
       body.innerHTML = '<div class="scope-empty">No per-function metrics available — use v2 rd_org input format for function-level analysis.</div>';
       return;
     }
@@ -1432,7 +1454,7 @@ import {
     table.appendChild(thead);
 
     const tbody = document.createElement("tbody");
-    model.forEach(fn => {
+    model.rows.forEach(fn => {
       const tr = document.createElement("tr");
       if (fn.isBottleneck) tr.className = "fn-bottleneck-row";
 
@@ -1488,10 +1510,17 @@ import {
     const droppedFeatures = selectedPlan.dropped_features ?? data.dropped_features ?? [];
 
     if (isSchedule) {
-      // Planning schedule: selected plan is primary — no baseline comparison
+      // Planning schedule: selected plan is primary — schedule-consequence framing, no baseline comparison
+      const depRulesPass = data.dependency_rules_pass ?? data.selected_plan?.dependency_rules_pass;
       const callout = document.createElement("div");
       callout.className = "schedule-primary-callout";
-      callout.textContent = "Showing selected plan scope — no baseline comparison in planning schedule mode.";
+      let calloutText = "Selected plan — dependency-aware schedule. Scope reflects what fits within the horizon once cross-function sequencing rules are applied.";
+      if (depRulesPass === true) {
+        calloutText += " All dependency rules pass.";
+      } else if (depRulesPass === false) {
+        calloutText += " Dependency rule violations detected — review Goals & Dependencies for details.";
+      }
+      callout.textContent = calloutText;
       body.appendChild(callout);
     } else if (lastInputData) {
       // Capacity check: show original vs selected comparison


### PR DESCRIPTION
Closes #79

## Summary
- add mode-aware summary context for capacity_check vs planning_schedule
- make planning_schedule summary and scope rendering dependency-aware
- expose function capacity-fit data for summary and function analysis surfaces
- lock the new mode-aware UI behavior in ui logic tests

## Verification
- node --test tests/ui_logic.test.mjs
- PYTHONPATH=src .venv/bin/python -m unittest tests.test_ui_spec
- PYTHONPATH=src .venv/bin/python -m unittest discover -s tests
- .venv/bin/ruff check .
