### PR TITLE
Expand structured editor for org roadmap and goals

### DIFF
--- a/tests/ui_logic.test.mjs
+++ b/tests/ui_logic.test.mjs
@@ -2,7 +2,11 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  applyBusinessGoalsToPayload,
   applyEditableFieldsToPayload,
+  applyOrgToPayload,
+  applyRoadmapFeaturesToPayload,
+  applySchedulePolicyToPayload,
   buildFunctionAnalysisModel,
   buildModeAwareSummaryContext,
   buildPeriodSource,
@@ -10,7 +14,11 @@ import {
   buildStructuredFormState,
   buildSummaryModel,
   getUtilizationStatus,
+  readBusinessGoalsFromPayload,
   readEditableFieldsFromPayload,
+  readOrgFromPayload,
+  readRoadmapFeaturesFromPayload,
+  readSchedulePolicyFromPayload,
   validateInputPayload,
 } from "../ui/app.js";
 
@@ -707,4 +715,602 @@ test("buildFunctionAnalysisModel fits is null when function_capacity_fit is abse
 
   const engRow = model.rows.find((r) => r.name === "eng");
   assert.equal(engRow.fits, null);
+});
+
+// --- readOrgFromPayload / applyOrgToPayload ---
+
+test("readOrgFromPayload extracts teams with members and typed country profile values", () => {
+  const data = {
+    rd_org: {
+      teams: [{
+        name: "Core Product",
+        members: [
+          {id: "eng-1", function: "eng", seniority: "Senior", country_profile: "us"},
+          {id: "qa-1", function: "qa", seniority: "Mid", capacity_percent: 0.5, country_profile: "us"},
+        ],
+      }],
+      country_profiles: [{id: "us", country_code: "US", vacation_days_per_employee: 18, sick_days_per_employee: 8}],
+    },
+  };
+  const org = readOrgFromPayload(data);
+  assert.equal(org.teams.length, 1);
+  assert.equal(org.teams[0].name, "Core Product");
+  assert.equal(org.teams[0].members[0].id, "eng-1");
+  assert.equal(org.teams[0].members[0].capacity_percent, "");
+  assert.equal(org.teams[0].members[1].capacity_percent, "0.5");
+  assert.equal(org.country_profiles[0].vacation_days_per_employee, 18);
+  assert.equal(org.country_profiles[0].sick_days_per_employee, 8);
+});
+
+test("readOrgFromPayload returns empty arrays when rd_org is absent", () => {
+  const org = readOrgFromPayload({});
+  assert.deepEqual(org.teams, []);
+  assert.deepEqual(org.country_profiles, []);
+});
+
+test("applyOrgToPayload round-trips teams and country profiles", () => {
+  const data = {
+    rd_org: {
+      teams: [{
+        name: "Core Product",
+        members: [{id: "eng-1", function: "eng", seniority: "Senior", country_profile: "us"}],
+      }],
+      country_profiles: [{id: "us", country_code: "US", vacation_days_per_employee: 18, sick_days_per_employee: 8}],
+    },
+  };
+  const org = readOrgFromPayload(data);
+  const result = applyOrgToPayload(data, org);
+  assert.equal(result.rd_org.teams[0].name, "Core Product");
+  assert.equal(result.rd_org.teams[0].members[0].id, "eng-1");
+  assert.equal(result.rd_org.country_profiles[0].id, "us");
+  assert.equal(result.rd_org.country_profiles[0].vacation_days_per_employee, 18);
+});
+
+test("applyOrgToPayload preserves unknown rd_org fields (e.g. org_schedule_policies)", () => {
+  const data = {
+    rd_org: {
+      org_schedule_policies: {post_dev_min_ratio: {qa: 0.4}},
+      teams: [{name: "T", members: [{id: "m1", function: "eng", seniority: "Senior", country_profile: "us"}]}],
+      country_profiles: [],
+    },
+  };
+  const org = readOrgFromPayload(data);
+  const result = applyOrgToPayload(data, org);
+  assert.deepEqual(result.rd_org.org_schedule_policies, {post_dev_min_ratio: {qa: 0.4}});
+});
+
+test("applyOrgToPayload preserves unknown member fields via id matching", () => {
+  const data = {
+    rd_org: {
+      teams: [{
+        name: "T",
+        members: [{id: "eng-1", function: "eng", seniority: "Senior", country_profile: "us", custom_tag: "alpha"}],
+      }],
+      country_profiles: [],
+    },
+  };
+  const org = readOrgFromPayload(data);
+  const result = applyOrgToPayload(data, org);
+  assert.equal(result.rd_org.teams[0].members[0].custom_tag, "alpha");
+});
+
+test("applyOrgToPayload omits capacity_percent when form value is empty", () => {
+  const data = {
+    rd_org: {
+      teams: [{
+        name: "T",
+        members: [{id: "m1", function: "eng", seniority: "Senior", country_profile: "us"}],
+      }],
+      country_profiles: [],
+    },
+  };
+  const org = readOrgFromPayload(data);
+  const result = applyOrgToPayload(data, org);
+  assert.equal("capacity_percent" in result.rd_org.teams[0].members[0], false);
+});
+
+// --- readSchedulePolicyFromPayload / applySchedulePolicyToPayload ---
+
+test("readSchedulePolicyFromPayload extracts qa and devops ratios as typed numbers", () => {
+  const data = {
+    rd_org: {org_schedule_policies: {post_dev_min_ratio: {qa: 0.4, devops: 0.3}}},
+  };
+  const policy = readSchedulePolicyFromPayload(data);
+  assert.equal(policy.qa, 0.4);
+  assert.equal(policy.devops, 0.3);
+});
+
+test("readSchedulePolicyFromPayload returns nulls when absent", () => {
+  const policy = readSchedulePolicyFromPayload({});
+  assert.equal(policy.qa, null);
+  assert.equal(policy.devops, null);
+});
+
+test("applySchedulePolicyToPayload round-trips schedule policies for planning_schedule", () => {
+  const data = {
+    planning_mode: "planning_schedule",
+    rd_org: {org_schedule_policies: {post_dev_min_ratio: {qa: 0.4, devops: 0.4}}, teams: []},
+  };
+  const policy = readSchedulePolicyFromPayload(data);
+  const result = applySchedulePolicyToPayload(data, policy);
+  assert.equal(result.rd_org.org_schedule_policies.post_dev_min_ratio.qa, 0.4);
+  assert.equal(result.rd_org.org_schedule_policies.post_dev_min_ratio.devops, 0.4);
+});
+
+test("applySchedulePolicyToPayload preserves unknown rd_org fields", () => {
+  const data = {
+    planning_mode: "planning_schedule",
+    rd_org: {
+      org_schedule_policies: {post_dev_min_ratio: {qa: 0.4}, other_policy: "keep"},
+      teams: [{name: "T", members: []}],
+    },
+  };
+  const result = applySchedulePolicyToPayload(data, {qa: 0.4, devops: 0.3});
+  assert.equal(result.rd_org.org_schedule_policies.other_policy, "keep");
+  assert.equal(result.rd_org.teams[0].name, "T");
+});
+
+test("applySchedulePolicyToPayload removes key when typed value is null", () => {
+  const data = {
+    planning_mode: "planning_schedule",
+    rd_org: {org_schedule_policies: {post_dev_min_ratio: {qa: 0.4, devops: 0.4}}, teams: []},
+  };
+  const result = applySchedulePolicyToPayload(data, {qa: 0.4, devops: null});
+  assert.equal(result.rd_org.org_schedule_policies.post_dev_min_ratio.qa, 0.4);
+  assert.equal("devops" in result.rd_org.org_schedule_policies.post_dev_min_ratio, false);
+});
+
+// --- readRoadmapFeaturesFromPayload / applyRoadmapFeaturesToPayload ---
+
+test("readRoadmapFeaturesFromPayload extracts features with per-function estimates", () => {
+  const data = {
+    roadmap: {
+      features: [{id: "f1", name: "Feature One", priority: "High", estimates: {eng: "M", qa: "S", devops: "XS"}}],
+    },
+  };
+  const features = readRoadmapFeaturesFromPayload(data);
+  assert.equal(features.length, 1);
+  assert.equal(features[0].id, "f1");
+  assert.deepEqual(features[0].estimates, {eng: "M", qa: "S", devops: "XS"});
+  assert.equal(features[0].size, "");
+});
+
+test("readRoadmapFeaturesFromPayload extracts top-level size field", () => {
+  const data = {
+    roadmap: {features: [{id: "f1", name: "Feature One", priority: "Critical", size: "L"}]},
+  };
+  const features = readRoadmapFeaturesFromPayload(data);
+  assert.equal(features[0].size, "L");
+  assert.deepEqual(features[0].estimates, {});
+});
+
+test("readRoadmapFeaturesFromPayload returns empty array when roadmap absent", () => {
+  assert.deepEqual(readRoadmapFeaturesFromPayload({}), []);
+});
+
+test("applyRoadmapFeaturesToPayload round-trips features with estimates", () => {
+  const data = {
+    roadmap: {
+      features: [{id: "f1", name: "Feature One", priority: "High", estimates: {eng: "M", qa: "S"}}],
+    },
+  };
+  const features = readRoadmapFeaturesFromPayload(data);
+  const result = applyRoadmapFeaturesToPayload(data, features);
+  assert.equal(result.roadmap.features[0].id, "f1");
+  assert.equal(result.roadmap.features[0].estimates.eng, "M");
+  assert.equal(result.roadmap.features[0].estimates.qa, "S");
+  assert.equal("devops" in result.roadmap.features[0].estimates, false);
+});
+
+test("applyRoadmapFeaturesToPayload preserves unknown feature fields via id matching", () => {
+  const data = {
+    roadmap: {
+      features: [{id: "f1", name: "F", priority: "High", estimates: {eng: "M"}, dependencies: ["f0"]}],
+    },
+  };
+  const features = readRoadmapFeaturesFromPayload(data);
+  const result = applyRoadmapFeaturesToPayload(data, features);
+  assert.deepEqual(result.roadmap.features[0].dependencies, ["f0"]);
+});
+
+test("applyRoadmapFeaturesToPayload preserves unknown roadmap fields", () => {
+  const data = {
+    roadmap: {
+      features: [{id: "f1", name: "A", priority: "High", estimates: {eng: "S"}}],
+      version: "2.0",
+    },
+  };
+  const features = readRoadmapFeaturesFromPayload(data);
+  const result = applyRoadmapFeaturesToPayload(data, features);
+  assert.equal(result.roadmap.version, "2.0");
+});
+
+// --- readBusinessGoalsFromPayload / applyBusinessGoalsToPayload ---
+
+test("readBusinessGoalsFromPayload returns must-deliver ids as typed array", () => {
+  const data = {
+    business_goals: {
+      must_deliver_feature_ids: ["f1", "f2"],
+      max_utilization: 0.85,
+      min_buffer_ratio: 0.1,
+    },
+  };
+  const goals = readBusinessGoalsFromPayload(data);
+  assert.deepEqual(goals.must_deliver_feature_ids, ["f1", "f2"]);
+  assert.equal(goals.max_utilization, 0.85);
+  assert.equal(goals.min_buffer_ratio, 0.1);
+});
+
+test("readBusinessGoalsFromPayload returns defaults when absent", () => {
+  const goals = readBusinessGoalsFromPayload({});
+  assert.deepEqual(goals.must_deliver_feature_ids, []);
+  assert.equal(goals.max_utilization, null);
+  assert.equal(goals.min_buffer_ratio, null);
+});
+
+test("applyBusinessGoalsToPayload round-trips business goals", () => {
+  const data = {
+    business_goals: {
+      must_deliver_feature_ids: ["f1", "f2"],
+      max_utilization: 0.85,
+      min_buffer_ratio: 0.1,
+    },
+  };
+  const goals = readBusinessGoalsFromPayload(data);
+  const result = applyBusinessGoalsToPayload(data, goals);
+  assert.deepEqual(result.business_goals.must_deliver_feature_ids, ["f1", "f2"]);
+  assert.equal(result.business_goals.max_utilization, 0.85);
+  assert.equal(result.business_goals.min_buffer_ratio, 0.1);
+});
+
+test("applyBusinessGoalsToPayload preserves unknown business_goals fields", () => {
+  const data = {
+    business_goals: {
+      must_deliver_feature_ids: ["f1"],
+      max_utilization: 0.9,
+      preserve_priorities: true,
+      defer_preference: "low",
+    },
+  };
+  const goals = readBusinessGoalsFromPayload(data);
+  const result = applyBusinessGoalsToPayload(data, goals);
+  assert.equal(result.business_goals.preserve_priorities, true);
+  assert.equal(result.business_goals.defer_preference, "low");
+});
+
+test("applyBusinessGoalsToPayload handles empty must-deliver input", () => {
+  const data = {business_goals: {must_deliver_feature_ids: ["f1"]}};
+  const result = applyBusinessGoalsToPayload(data, {
+    must_deliver_feature_ids: [],
+    max_utilization: null,
+    min_buffer_ratio: null,
+  });
+  assert.deepEqual(result.business_goals.must_deliver_feature_ids, []);
+  assert.equal("max_utilization" in result.business_goals, false);
+  assert.equal("min_buffer_ratio" in result.business_goals, false);
+});
+
+// --- Structured editor helpers ---
+
+// Teams and members
+
+test("readOrgFromPayload reads teams and members from rd_org", () => {
+  const data = {
+    planning_mode: "capacity_check",
+    rd_org: {
+      country_profiles: [{id: "us", country_code: "US"}],
+      teams: [
+        {
+          name: "Core Product",
+          members: [
+            {id: "eng-1", function: "eng", seniority: "Senior", country_profile: "us"},
+            {id: "qa-1", function: "qa", seniority: "Mid", country_profile: "us"},
+          ],
+        },
+      ],
+    },
+  };
+
+  const org = readOrgFromPayload(data);
+
+  assert.equal(org.teams.length, 1);
+  assert.equal(org.teams[0].name, "Core Product");
+  assert.equal(org.teams[0].members.length, 2);
+  assert.equal(org.teams[0].members[0].id, "eng-1");
+  assert.equal(org.teams[0].members[1].function, "qa");
+});
+
+test("readOrgFromPayload returns empty arrays when rd_org is absent", () => {
+  const org = readOrgFromPayload({planning_mode: "capacity_check"});
+
+  assert.deepEqual(org.teams, []);
+  assert.deepEqual(org.country_profiles, []);
+});
+
+test("applyOrgToPayload writes teams back and preserves org_schedule_policies", () => {
+  const original = {
+    planning_mode: "planning_schedule",
+    rd_org: {
+      org_schedule_policies: {post_dev_min_ratio: {qa: 0.4, devops: 0.4}},
+      country_profiles: [{id: "il", country_code: "IL"}],
+      teams: [{name: "Old Team", members: []}],
+    },
+  };
+
+  const orgState = {
+    teams: [{name: "New Team", members: [{id: "eng-1", function: "eng", seniority: "Senior", country_profile: "il"}]}],
+    country_profiles: [{id: "il", country_code: "IL"}],
+  };
+
+  const updated = applyOrgToPayload(original, orgState);
+
+  assert.equal(updated.rd_org.teams.length, 1);
+  assert.equal(updated.rd_org.teams[0].name, "New Team");
+  assert.deepEqual(updated.rd_org.org_schedule_policies, {post_dev_min_ratio: {qa: 0.4, devops: 0.4}});
+  assert.equal(updated.planning_mode, "planning_schedule");
+});
+
+test("applyOrgToPayload seeds empty rd_org when absent", () => {
+  const original = {planning_mode: "capacity_check"};
+
+  const orgState = {
+    teams: [{name: "Alpha", members: []}],
+    country_profiles: [],
+  };
+
+  const updated = applyOrgToPayload(original, orgState);
+
+  assert.ok(updated.rd_org);
+  assert.equal(updated.rd_org.teams[0].name, "Alpha");
+  assert.deepEqual(updated.rd_org.country_profiles, []);
+});
+
+// Country profiles
+
+test("readOrgFromPayload reads country_profiles with all fields", () => {
+  const data = {
+    rd_org: {
+      country_profiles: [
+        {
+          id: "us",
+          country_code: "US",
+          working_day_rules: {workweek: "mon-fri"},
+          holiday_calendar_rules: {dates: ["2026-07-04"]},
+          vacation_days_per_employee: 18,
+          sick_days_per_employee: 8,
+        },
+      ],
+      teams: [],
+    },
+  };
+
+  const org = readOrgFromPayload(data);
+
+  assert.equal(org.country_profiles.length, 1);
+  assert.equal(org.country_profiles[0].id, "us");
+  assert.equal(org.country_profiles[0].country_code, "US");
+  assert.equal(org.country_profiles[0].vacation_days_per_employee, 18);
+  assert.deepEqual(org.country_profiles[0].working_day_rules, {workweek: "mon-fri"});
+});
+
+test("applyOrgToPayload round-trips country_profiles without loss", () => {
+  const profiles = [
+    {
+      id: "us",
+      country_code: "US",
+      working_day_rules: {workweek: "mon-fri"},
+      holiday_calendar_rules: {dates: ["2026-07-04"]},
+      vacation_days_per_employee: 18,
+      sick_days_per_employee: 8,
+    },
+  ];
+  const original = {rd_org: {country_profiles: profiles, teams: []}};
+
+  const org = readOrgFromPayload(original);
+  const updated = applyOrgToPayload(original, org);
+
+  assert.deepEqual(updated.rd_org.country_profiles, profiles);
+});
+
+// Schedule policy
+
+test("readSchedulePolicyFromPayload reads post_dev_min_ratio for planning_schedule", () => {
+  const data = {
+    planning_mode: "planning_schedule",
+    rd_org: {
+      org_schedule_policies: {
+        post_dev_min_ratio: {qa: 0.4, devops: 0.3},
+      },
+      teams: [],
+      country_profiles: [],
+    },
+  };
+
+  const policy = readSchedulePolicyFromPayload(data);
+
+  assert.equal(policy.qa, 0.4);
+  assert.equal(policy.devops, 0.3);
+});
+
+test("readSchedulePolicyFromPayload returns nulls when policy is absent", () => {
+  const policy = readSchedulePolicyFromPayload({planning_mode: "capacity_check"});
+
+  assert.equal(policy.qa, null);
+  assert.equal(policy.devops, null);
+});
+
+test("applySchedulePolicyToPayload writes post_dev_min_ratio for planning_schedule", () => {
+  const original = {
+    planning_mode: "planning_schedule",
+    rd_org: {
+      teams: [],
+      country_profiles: [],
+    },
+  };
+
+  const updated = applySchedulePolicyToPayload(original, {qa: 0.4, devops: 0.5});
+
+  assert.equal(updated.rd_org.org_schedule_policies.post_dev_min_ratio.qa, 0.4);
+  assert.equal(updated.rd_org.org_schedule_policies.post_dev_min_ratio.devops, 0.5);
+  assert.deepEqual(updated.rd_org.teams, []);
+});
+
+test("applySchedulePolicyToPayload preserves existing org_schedule_policies fields", () => {
+  const original = {
+    planning_mode: "planning_schedule",
+    rd_org: {
+      org_schedule_policies: {
+        post_dev_min_ratio: {qa: 0.3, devops: 0.3},
+        extra_policy: "keep_me",
+      },
+      teams: [],
+      country_profiles: [],
+    },
+  };
+
+  const updated = applySchedulePolicyToPayload(original, {qa: 0.5, devops: 0.5});
+
+  assert.equal(updated.rd_org.org_schedule_policies.extra_policy, "keep_me");
+  assert.equal(updated.rd_org.org_schedule_policies.post_dev_min_ratio.qa, 0.5);
+});
+
+test("applySchedulePolicyToPayload removes org_schedule_policies for capacity_check", () => {
+  const original = {
+    planning_mode: "capacity_check",
+    rd_org: {
+      teams: [],
+      country_profiles: [],
+      org_schedule_policies: {post_dev_min_ratio: {qa: 0.4, devops: 0.4}},
+    },
+  };
+
+  const updated = applySchedulePolicyToPayload(original, {qa: 0.4, devops: 0.4});
+
+  assert.equal(updated.rd_org.org_schedule_policies, undefined);
+  assert.deepEqual(updated.rd_org.teams, []);
+  assert.deepEqual(updated.rd_org.country_profiles, []);
+});
+
+// Roadmap feature estimates
+
+test("readRoadmapFeaturesFromPayload reads features with function estimates", () => {
+  const data = {
+    roadmap: {
+      features: [
+        {id: "f-1", name: "Auth", priority: "High", estimates: {eng: "M", qa: "S"}},
+        {id: "f-2", name: "Export", priority: "Low", estimates: {eng: "L", devops: "XS"}},
+      ],
+    },
+  };
+
+  const features = readRoadmapFeaturesFromPayload(data);
+
+  assert.equal(features.length, 2);
+  assert.equal(features[0].id, "f-1");
+  assert.deepEqual(features[0].estimates, {eng: "M", qa: "S"});
+  assert.equal(features[1].estimates.devops, "XS");
+});
+
+test("readRoadmapFeaturesFromPayload returns empty array when roadmap is absent", () => {
+  const features = readRoadmapFeaturesFromPayload({});
+
+  assert.deepEqual(features, []);
+});
+
+test("applyRoadmapFeaturesToPayload writes features preserving other roadmap fields", () => {
+  const original = {
+    roadmap: {
+      features: [{id: "f-1", name: "Old", priority: "Low", estimates: {eng: "S"}}],
+      roadmap_version: "v2",
+    },
+  };
+
+  const newFeatures = [
+    {id: "f-1", name: "Old", priority: "High", estimates: {eng: "M", qa: "S"}},
+  ];
+
+  const updated = applyRoadmapFeaturesToPayload(original, newFeatures);
+
+  assert.equal(updated.roadmap.features[0].priority, "High");
+  assert.deepEqual(updated.roadmap.features[0].estimates, {eng: "M", qa: "S"});
+  assert.equal(updated.roadmap.roadmap_version, "v2");
+});
+
+test("applyRoadmapFeaturesToPayload preserves unknown feature fields during round-trip", () => {
+  const features = [
+    {id: "f-1", name: "Auth", priority: "High", estimates: {eng: "M"}, tags: ["security"], internal_note: "urgent"},
+  ];
+  const original = {roadmap: {features}};
+
+  const read = readRoadmapFeaturesFromPayload(original);
+  const updated = applyRoadmapFeaturesToPayload(original, read);
+
+  assert.deepEqual(updated.roadmap.features[0].tags, ["security"]);
+  assert.equal(updated.roadmap.features[0].internal_note, "urgent");
+});
+
+// Business goals
+
+test("readBusinessGoalsFromPayload reads must_deliver_feature_ids and utilization goals", () => {
+  const data = {
+    business_goals: {
+      must_deliver_feature_ids: ["f-1", "f-2"],
+      preserve_priorities: ["Critical"],
+      max_utilization: 0.9,
+      min_buffer_ratio: 0.1,
+    },
+  };
+
+  const goals = readBusinessGoalsFromPayload(data);
+
+  assert.deepEqual(goals.must_deliver_feature_ids, ["f-1", "f-2"]);
+  assert.equal(goals.max_utilization, 0.9);
+  assert.equal(goals.min_buffer_ratio, 0.1);
+});
+
+test("readBusinessGoalsFromPayload returns defaults when business_goals is absent", () => {
+  const goals = readBusinessGoalsFromPayload({});
+
+  assert.deepEqual(goals.must_deliver_feature_ids, []);
+  assert.equal(goals.max_utilization, null);
+  assert.equal(goals.min_buffer_ratio, null);
+});
+
+test("applyBusinessGoalsToPayload writes goals preserving other business_goal fields", () => {
+  const original = {
+    business_goals: {
+      must_deliver_feature_ids: ["f-1"],
+      preserve_priorities: ["Critical", "High"],
+      defer_preference: ["Low"],
+      max_utilization: 0.85,
+      min_buffer_ratio: 0.1,
+    },
+  };
+
+  const goalsState = {
+    must_deliver_feature_ids: ["f-1", "f-3"],
+    max_utilization: 0.9,
+    min_buffer_ratio: 0.15,
+  };
+
+  const updated = applyBusinessGoalsToPayload(original, goalsState);
+
+  assert.deepEqual(updated.business_goals.must_deliver_feature_ids, ["f-1", "f-3"]);
+  assert.equal(updated.business_goals.max_utilization, 0.9);
+  assert.equal(updated.business_goals.min_buffer_ratio, 0.15);
+  assert.deepEqual(updated.business_goals.preserve_priorities, ["Critical", "High"]);
+  assert.deepEqual(updated.business_goals.defer_preference, ["Low"]);
+});
+
+test("applyBusinessGoalsToPayload seeds business_goals when absent", () => {
+  const original = {planning_mode: "capacity_check"};
+
+  const updated = applyBusinessGoalsToPayload(original, {
+    must_deliver_feature_ids: ["f-99"],
+    max_utilization: 0.9,
+    min_buffer_ratio: 0.1,
+  });
+
+  assert.deepEqual(updated.business_goals.must_deliver_feature_ids, ["f-99"]);
+  assert.equal(updated.business_goals.max_utilization, 0.9);
 });

--- a/ui/app.js
+++ b/ui/app.js
@@ -256,6 +256,219 @@ export function buildFunctionAnalysisModel(result) {
   };
 }
 
+// --- Structured editor helpers ---
+
+// Organization: read normalises member/profile values to strings for form inputs.
+export function readOrgFromPayload(data) {
+  const rdOrg = data.rd_org ?? {};
+  const teams = (rdOrg.teams ?? []).map(t => ({
+    name: t.name ?? "",
+    members: (t.members ?? []).map(m => ({
+      id: m.id ?? "",
+      function: m.function ?? "",
+      seniority: m.seniority ?? "",
+      capacity_percent: m.capacity_percent !== undefined ? String(m.capacity_percent) : "",
+      country_profile: m.country_profile ?? "",
+    })),
+  }));
+  const country_profiles = (rdOrg.country_profiles ?? []).map(p => ({
+    ...p,
+    id: p.id ?? "",
+    country_code: p.country_code ?? "",
+    vacation_days_per_employee: p.vacation_days_per_employee !== undefined ? p.vacation_days_per_employee : null,
+    sick_days_per_employee: p.sick_days_per_employee !== undefined ? p.sick_days_per_employee : null,
+  }));
+  return { teams, country_profiles };
+}
+
+// Organization: apply merges form state back into payload, preserving unknown fields
+// on teams, members, and country profiles via id-based matching.
+export function applyOrgToPayload(data, { teams, country_profiles }) {
+  const next = { ...data };
+  const existingRdOrg = data.rd_org ?? {};
+
+  const existingProfilesById = Object.fromEntries(
+    (existingRdOrg.country_profiles ?? []).map(p => [p.id, p])
+  );
+
+  const nextTeams = teams.map((t, ti) => {
+    const existingTeam = (existingRdOrg.teams ?? [])[ti] ?? {};
+    const existingMembersById = Object.fromEntries(
+      (existingTeam.members ?? []).map(m => [m.id, m])
+    );
+    const nextMembers = t.members.map(m => {
+      const existing = existingMembersById[m.id] ?? {};
+      const nextMember = { ...existing };
+      if (m.id) nextMember.id = m.id;
+      if (m.function) nextMember.function = m.function;
+      if (m.seniority) nextMember.seniority = m.seniority;
+      if (m.country_profile) nextMember.country_profile = m.country_profile;
+      const cap = Number.parseFloat(m.capacity_percent);
+      if (!Number.isNaN(cap)) {
+        nextMember.capacity_percent = cap;
+      } else {
+        delete nextMember.capacity_percent;
+      }
+      return nextMember;
+    });
+    return { ...existingTeam, name: t.name, members: nextMembers };
+  });
+
+  const nextProfiles = country_profiles.map(p => {
+    const existing = existingProfilesById[p.id] ?? {};
+    const nextProfile = { ...existing };
+    if (p.id) nextProfile.id = p.id;
+    if (p.country_code) nextProfile.country_code = p.country_code;
+    const vac = Number.parseFloat(p.vacation_days_per_employee);
+    if (!Number.isNaN(vac)) nextProfile.vacation_days_per_employee = vac;
+    const sick = Number.parseFloat(p.sick_days_per_employee);
+    if (!Number.isNaN(sick)) nextProfile.sick_days_per_employee = sick;
+    return nextProfile;
+  });
+
+  next.rd_org = { ...existingRdOrg, teams: nextTeams, country_profiles: nextProfiles };
+  return next;
+}
+
+// Schedule policies: read returns typed values (number or null when absent).
+export function readSchedulePolicyFromPayload(data) {
+  const ratio = data.rd_org?.org_schedule_policies?.post_dev_min_ratio ?? {};
+  return {
+    qa: ratio.qa !== undefined ? ratio.qa : null,
+    devops: ratio.devops !== undefined ? ratio.devops : null,
+  };
+}
+
+// Schedule policies: apply updates post_dev_min_ratio, preserving unknown rd_org and
+// org_schedule_policies fields. When capacity_check is active, the schedule-policy
+// block is removed entirely because it is not valid for that mode.
+// Removes a key when the typed value is null/undefined.
+export function applySchedulePolicyToPayload(data, policyState) {
+  const next = { ...data };
+  const existingRdOrg = data.rd_org ?? {};
+  if (data.planning_mode === "capacity_check") {
+    if (!existingRdOrg.org_schedule_policies) {
+      return data;
+    }
+    const { org_schedule_policies, ...restRdOrg } = existingRdOrg;
+    next.rd_org = restRdOrg;
+    return next;
+  }
+  const existingPolicies = existingRdOrg.org_schedule_policies ?? {};
+  const existingRatio = existingPolicies.post_dev_min_ratio ?? {};
+
+  const nextRatio = { ...existingRatio };
+  if (policyState.qa !== null && policyState.qa !== undefined) {
+    nextRatio.qa = policyState.qa;
+  } else {
+    delete nextRatio.qa;
+  }
+  if (policyState.devops !== null && policyState.devops !== undefined) {
+    nextRatio.devops = policyState.devops;
+  } else {
+    delete nextRatio.devops;
+  }
+
+  next.rd_org = {
+    ...existingRdOrg,
+    org_schedule_policies: {
+      ...existingPolicies,
+      post_dev_min_ratio: nextRatio,
+    },
+  };
+  return next;
+}
+
+// Roadmap: read normalises features to form state, preserving nested estimates structure.
+export function readRoadmapFeaturesFromPayload(data) {
+  return (data.roadmap?.features ?? []).map(f => ({
+    id: f.id ?? "",
+    name: f.name ?? "",
+    priority: f.priority ?? "",
+    size: f.size ?? "",
+    estimates: f.estimates ? { ...f.estimates } : {},
+  }));
+}
+
+// Roadmap: apply converts form feature objects back to proper schema objects,
+// rebuilding estimates from flat fields and preserving unknown feature fields via id.
+export function applyRoadmapFeaturesToPayload(data, features) {
+  const next = { ...data };
+  const existingRoadmap = data.roadmap ?? {};
+  const existingFeaturesById = Object.fromEntries(
+    (existingRoadmap.features ?? []).map(f => [f.id, f])
+  );
+
+  const nextFeatures = features.map(f => {
+    const existing = existingFeaturesById[f.id] ?? {};
+    const nextF = { ...existing };
+    if (f.id) nextF.id = f.id;
+    if (f.name) nextF.name = f.name;
+    if (f.priority) nextF.priority = f.priority;
+    if (f.size) {
+      nextF.size = f.size;
+    } else {
+      delete nextF.size;
+    }
+
+    const existingEstimates = existing.estimates ?? {};
+    const formEstimates = f.estimates ?? {};
+    const nextEstimates = { ...existingEstimates, ...formEstimates };
+    // Remove keys explicitly set to empty string in form state
+    for (const key of Object.keys(nextEstimates)) {
+      if (formEstimates[key] === "") delete nextEstimates[key];
+    }
+
+    if (Object.keys(nextEstimates).length > 0) {
+      nextF.estimates = nextEstimates;
+    } else {
+      delete nextF.estimates;
+    }
+
+    return nextF;
+  });
+
+  next.roadmap = { ...existingRoadmap, features: nextFeatures };
+  return next;
+}
+
+// Business goals: read returns typed values (array for ids, numbers or null).
+export function readBusinessGoalsFromPayload(data) {
+  const goals = data.business_goals ?? {};
+  return {
+    must_deliver_feature_ids: Array.isArray(goals.must_deliver_feature_ids) ? goals.must_deliver_feature_ids : [],
+    max_utilization: goals.max_utilization !== undefined ? goals.max_utilization : null,
+    min_buffer_ratio: goals.min_buffer_ratio !== undefined ? goals.min_buffer_ratio : null,
+  };
+}
+
+// Business goals: apply accepts typed values (array for ids, numbers or null),
+// preserving unknown business_goals fields.
+export function applyBusinessGoalsToPayload(data, goalsState) {
+  const next = { ...data };
+  const existingGoals = data.business_goals ?? {};
+  const nextGoals = { ...existingGoals };
+
+  nextGoals.must_deliver_feature_ids = Array.isArray(goalsState.must_deliver_feature_ids)
+    ? goalsState.must_deliver_feature_ids
+    : [];
+
+  if (goalsState.max_utilization !== null && goalsState.max_utilization !== undefined) {
+    nextGoals.max_utilization = goalsState.max_utilization;
+  } else {
+    delete nextGoals.max_utilization;
+  }
+
+  if (goalsState.min_buffer_ratio !== null && goalsState.min_buffer_ratio !== undefined) {
+    nextGoals.min_buffer_ratio = goalsState.min_buffer_ratio;
+  } else {
+    delete nextGoals.min_buffer_ratio;
+  }
+
+  next.business_goals = nextGoals;
+  return next;
+}
+
 export function buildPeriodSource(data, rawFieldValues) {
   const calendarYear = parseFormInteger(rawFieldValues.calendar_year) ?? data.calendar_year;
   const halfYearIndex = parseFormInteger(rawFieldValues.half_year_index) ?? data.half_year_index;

--- a/ui/index.html
+++ b/ui/index.html
@@ -790,6 +790,87 @@ details[open] summary::before { content: "\25BC\00a0"; }
 @media (max-width: 600px) {
   .function-row { grid-template-columns: 1fr 1fr; }
 }
+/* Row-based structured editors */
+.org-team-block {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px 12px;
+  margin-bottom: 8px;
+  background: var(--bg);
+}
+.org-team-name-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+.org-team-name-row input {
+  flex: 1;
+  font-family: var(--sans);
+  font-size: 13px;
+  font-weight: 600;
+  padding: 5px 8px;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  background: var(--surface);
+  color: var(--text);
+}
+.row-editor-header {
+  display: grid;
+  gap: 5px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  color: var(--text-secondary);
+  margin-bottom: 3px;
+  padding: 0 2px;
+}
+.member-row { display: grid; grid-template-columns: 1fr 1fr 1fr 60px 76px 26px; gap: 5px; align-items: center; margin-bottom: 4px; }
+.profile-row { display: grid; grid-template-columns: 68px 78px 68px 68px 26px; gap: 5px; align-items: center; margin-bottom: 4px; }
+.feature-row { display: grid; grid-template-columns: 72px 1fr 88px 48px 48px 48px 48px 26px; gap: 5px; align-items: center; margin-bottom: 4px; }
+.row-editor-header.member-row { grid-template-columns: 1fr 1fr 1fr 60px 76px 26px; }
+.row-editor-header.profile-row { grid-template-columns: 68px 78px 68px 68px 26px; }
+.row-editor-header.feature-row { grid-template-columns: 72px 1fr 88px 48px 48px 48px 48px 26px; }
+.member-row input, .member-row select,
+.profile-row input, .profile-row select,
+.feature-row input, .feature-row select {
+  font-family: var(--sans);
+  font-size: 12px;
+  padding: 4px 5px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--surface);
+  color: var(--text);
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+}
+.member-row input:focus, .member-row select:focus,
+.profile-row input:focus, .profile-row select:focus,
+.feature-row input:focus, .feature-row select:focus {
+  outline: 1px solid var(--accent);
+  border-color: transparent;
+}
+.row-remove-btn {
+  font-size: 14px;
+  font-weight: 700;
+  width: 24px;
+  height: 24px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  flex-shrink: 0;
+  font-family: var(--sans);
+}
+.row-remove-btn:hover { background: var(--red-bg); color: var(--red); border-color: #fecaca; }
+.row-add-btn-row { margin-top: 4px; }
 </style>
 </head>
 <body>
@@ -936,9 +1017,59 @@ details[open] summary::before { content: "\25BC\00a0"; }
                 </div>
               </div>
 
-              <p class="form-hint">
-                Team structure, roadmap features, and business goals are edited in the JSON tab.
-                Changes here sync to JSON automatically.
+              <!-- Schedule Policies (visible only for planning_schedule) -->
+              <div id="schedule-policies-section" style="display:none">
+                <div class="section-label" style="margin-top:14px">Schedule Policies</div>
+                <div class="field-grid">
+                  <div class="field-group">
+                    <label>QA Min Ratio</label>
+                    <input type="number" id="f-sp-qa" min="0" max="1" step="0.05" placeholder="0.4">
+                  </div>
+                  <div class="field-group">
+                    <label>DevOps Min Ratio</label>
+                    <input type="number" id="f-sp-devops" min="0" max="1" step="0.05" placeholder="0.4">
+                  </div>
+                </div>
+              </div>
+
+              <!-- Organization -->
+              <div class="section-label" style="margin-top:14px">Organization — Teams</div>
+              <div id="org-teams-container"></div>
+              <div class="row-add-btn-row">
+                <button class="btn btn-sm" id="org-add-team-btn" type="button">+ Add Team</button>
+              </div>
+              <div class="section-label" style="margin-top:12px">Country Profiles</div>
+              <div id="org-profiles-container"></div>
+              <div class="row-add-btn-row">
+                <button class="btn btn-sm" id="org-add-profile-btn" type="button">+ Add Profile</button>
+              </div>
+
+              <!-- Roadmap -->
+              <div class="section-label" style="margin-top:14px">Roadmap Features</div>
+              <div id="roadmap-features-container"></div>
+              <div class="row-add-btn-row">
+                <button class="btn btn-sm" id="roadmap-add-feature-btn" type="button">+ Add Feature</button>
+              </div>
+
+              <!-- Business Goals -->
+              <div class="section-label" style="margin-top:14px">Business Goals</div>
+              <div class="field-grid">
+                <div class="field-group" style="grid-column:1/-1">
+                  <label>Must-Deliver IDs (comma-separated)</label>
+                  <input type="text" id="f-bg-must-deliver" placeholder="feature-1, feature-2">
+                </div>
+                <div class="field-group">
+                  <label>Max Utilization</label>
+                  <input type="number" id="f-bg-max-util" min="0" max="1" step="0.05" placeholder="0.9">
+                </div>
+                <div class="field-group">
+                  <label>Min Buffer Ratio</label>
+                  <input type="number" id="f-bg-min-buffer" min="0" max="1" step="0.05" placeholder="0.1">
+                </div>
+              </div>
+
+              <p class="form-hint" style="margin-top:14px">
+                Changes to any field sync to JSON automatically. Use the JSON tab for full fidelity; unknown fields are preserved.
               </p>
             </div>
           </div>
@@ -1044,14 +1175,22 @@ details[open] summary::before { content: "\25BC\00a0"; }
 
 <script type="module">
 import {
+  applyBusinessGoalsToPayload,
   applyEditableFieldsToPayload,
+  applyOrgToPayload,
+  applyRoadmapFeaturesToPayload,
+  applySchedulePolicyToPayload,
   buildFunctionAnalysisModel,
   buildModeAwareSummaryContext,
   buildPlanComparison,
   buildStructuredFormState,
   buildSummaryModel,
   getUtilizationStatus,
+  readBusinessGoalsFromPayload,
   readEditableFieldsFromPayload,
+  readOrgFromPayload,
+  readRoadmapFeaturesFromPayload,
+  readSchedulePolicyFromPayload,
   validateInputPayload,
 } from "/assets/app.js";
 
@@ -1094,6 +1233,11 @@ import {
 
   let lastResult = null;
   let lastInputData = null;
+
+  // In-memory state for dynamic row editors. Populated by syncFormFromJson,
+  // written back to JSON by syncJsonFromOrg / syncJsonFromRoadmap.
+  let orgState = { teams: [], country_profiles: [] };
+  let roadmapState = [];
 
   // --- Load examples ---
   fetch("/api/examples").then(r => r.json()).then(examples => {
@@ -1191,10 +1335,286 @@ import {
     document.getElementById("ps-end-date").style.display = h === "sprint" ? "" : "none";
   }
 
-  // --- Form <-> JSON sync ---
+  function updateSchedulePoliciesVisibility() {
+    const isSchedule = formFields.mode.value === "planning_schedule";
+    document.getElementById("schedule-policies-section").style.display = isSchedule ? "" : "none";
+  }
+
+  // --- Org row rendering ---
+
+  const SIZE_OPTIONS = ["", "XS", "S", "M", "L", "XL"];
+  const PRIORITY_OPTIONS = ["", "Critical", "High", "Medium", "Low"];
+  const FN_OPTIONS = ["", "eng", "qa", "devops", "design", "pm", "data"];
+  const SENIORITY_OPTIONS = ["", "Junior", "Mid", "Senior", "Staff", "Principal"];
+
+  function makeSelect(options, currentValue) {
+    const sel = document.createElement("select");
+    options.forEach(opt => {
+      const o = document.createElement("option");
+      o.value = opt;
+      o.textContent = opt || "—";
+      if (opt === currentValue) o.selected = true;
+      sel.appendChild(o);
+    });
+    return sel;
+  }
+
+  function makeInput(type, value, placeholder, attrs) {
+    const inp = document.createElement("input");
+    inp.type = type;
+    inp.value = value;
+    if (placeholder) inp.placeholder = placeholder;
+    if (attrs) Object.assign(inp, attrs);
+    return inp;
+  }
+
+  function makeRemoveBtn() {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "row-remove-btn";
+    btn.textContent = "\u00d7";
+    return btn;
+  }
+
+  function renderOrgTeams() {
+    const container = document.getElementById("org-teams-container");
+    container.innerHTML = "";
+    orgState.teams.forEach((team, ti) => {
+      const block = document.createElement("div");
+      block.className = "org-team-block";
+
+      // Team name row
+      const nameRow = document.createElement("div");
+      nameRow.className = "org-team-name-row";
+      const nameInp = makeInput("text", team.name, "Team name");
+      nameInp.addEventListener("input", function() {
+        orgState.teams[ti].name = this.value;
+        syncJsonFromOrg();
+      });
+      const removeTeamBtn = makeRemoveBtn();
+      removeTeamBtn.addEventListener("click", function() {
+        orgState.teams.splice(ti, 1);
+        renderOrgTeams();
+        syncJsonFromOrg();
+      });
+      nameRow.append(nameInp, removeTeamBtn);
+      block.appendChild(nameRow);
+
+      // Member header
+      if (team.members.length > 0) {
+        const hdr = document.createElement("div");
+        hdr.className = "row-editor-header member-row";
+        ["ID", "Function", "Seniority", "Cap%", "Country", ""].forEach(h => {
+          const s = document.createElement("span");
+          s.textContent = h;
+          hdr.appendChild(s);
+        });
+        block.appendChild(hdr);
+      }
+
+      // Member rows
+      team.members.forEach((member, mi) => {
+        const row = document.createElement("div");
+        row.className = "member-row";
+
+        const idInp = makeInput("text", member.id, "id");
+        idInp.addEventListener("input", function() {
+          orgState.teams[ti].members[mi].id = this.value;
+          syncJsonFromOrg();
+        });
+
+        const fnSel = makeSelect(FN_OPTIONS, member.function);
+        fnSel.addEventListener("change", function() {
+          orgState.teams[ti].members[mi].function = this.value;
+          syncJsonFromOrg();
+        });
+
+        const senSel = makeSelect(SENIORITY_OPTIONS, member.seniority);
+        senSel.addEventListener("change", function() {
+          orgState.teams[ti].members[mi].seniority = this.value;
+          syncJsonFromOrg();
+        });
+
+        const capInp = makeInput("number", member.capacity_percent, "1.0", {min: "0", max: "1", step: "0.1"});
+        capInp.addEventListener("input", function() {
+          orgState.teams[ti].members[mi].capacity_percent = this.value;
+          syncJsonFromOrg();
+        });
+
+        const countryInp = makeInput("text", member.country_profile, "profile id");
+        countryInp.addEventListener("input", function() {
+          orgState.teams[ti].members[mi].country_profile = this.value;
+          syncJsonFromOrg();
+        });
+
+        const removeBtn = makeRemoveBtn();
+        removeBtn.addEventListener("click", function() {
+          orgState.teams[ti].members.splice(mi, 1);
+          renderOrgTeams();
+          syncJsonFromOrg();
+        });
+
+        row.append(idInp, fnSel, senSel, capInp, countryInp, removeBtn);
+        block.appendChild(row);
+      });
+
+      // Add member button
+      const addMemberBtn = document.createElement("button");
+      addMemberBtn.type = "button";
+      addMemberBtn.className = "btn btn-sm";
+      addMemberBtn.textContent = "+ Add Member";
+      addMemberBtn.style.marginTop = "6px";
+      addMemberBtn.addEventListener("click", function() {
+        orgState.teams[ti].members.push({id: "", function: "", seniority: "", capacity_percent: "", country_profile: ""});
+        renderOrgTeams();
+        syncJsonFromOrg();
+      });
+      block.appendChild(addMemberBtn);
+
+      container.appendChild(block);
+    });
+  }
+
+  function renderOrgProfiles() {
+    const container = document.getElementById("org-profiles-container");
+    container.innerHTML = "";
+
+    if (orgState.country_profiles.length > 0) {
+      const hdr = document.createElement("div");
+      hdr.className = "row-editor-header profile-row";
+      ["ID", "Country Code", "Vacation", "Sick Days", ""].forEach(h => {
+        const s = document.createElement("span");
+        s.textContent = h;
+        hdr.appendChild(s);
+      });
+      container.appendChild(hdr);
+    }
+
+    orgState.country_profiles.forEach((profile, pi) => {
+      const row = document.createElement("div");
+      row.className = "profile-row";
+
+      const idInp = makeInput("text", profile.id, "id");
+      idInp.addEventListener("input", function() {
+        orgState.country_profiles[pi].id = this.value;
+        syncJsonFromOrg();
+      });
+
+      const codeInp = makeInput("text", profile.country_code, "US");
+      codeInp.addEventListener("input", function() {
+        orgState.country_profiles[pi].country_code = this.value;
+        syncJsonFromOrg();
+      });
+
+      const vacInp = makeInput("number", profile.vacation_days_per_employee ?? "", "18", {min: "0"});
+      vacInp.addEventListener("input", function() {
+        orgState.country_profiles[pi].vacation_days_per_employee = this.value;
+        syncJsonFromOrg();
+      });
+
+      const sickInp = makeInput("number", profile.sick_days_per_employee ?? "", "8", {min: "0"});
+      sickInp.addEventListener("input", function() {
+        orgState.country_profiles[pi].sick_days_per_employee = this.value;
+        syncJsonFromOrg();
+      });
+
+      const removeBtn = makeRemoveBtn();
+      removeBtn.addEventListener("click", function() {
+        orgState.country_profiles.splice(pi, 1);
+        renderOrgProfiles();
+        syncJsonFromOrg();
+      });
+
+      row.append(idInp, codeInp, vacInp, sickInp, removeBtn);
+      container.appendChild(row);
+    });
+  }
+
+  // --- Roadmap row rendering ---
+
+  function renderRoadmapFeatures() {
+    const container = document.getElementById("roadmap-features-container");
+    container.innerHTML = "";
+
+    if (roadmapState.length > 0) {
+      const hdr = document.createElement("div");
+      hdr.className = "row-editor-header feature-row";
+      ["ID", "Name", "Priority", "Size", "Eng", "QA", "DevOps", ""].forEach(h => {
+        const s = document.createElement("span");
+        s.textContent = h;
+        hdr.appendChild(s);
+      });
+      container.appendChild(hdr);
+    }
+
+    roadmapState.forEach((feature, fi) => {
+      const row = document.createElement("div");
+      row.className = "feature-row";
+
+      const idInp = makeInput("text", feature.id, "id");
+      idInp.addEventListener("input", function() {
+        roadmapState[fi].id = this.value;
+        syncJsonFromRoadmap();
+      });
+
+      const nameInp = makeInput("text", feature.name, "Feature name");
+      nameInp.addEventListener("input", function() {
+        roadmapState[fi].name = this.value;
+        syncJsonFromRoadmap();
+      });
+
+      const priSel = makeSelect(PRIORITY_OPTIONS, feature.priority);
+      priSel.addEventListener("change", function() {
+        roadmapState[fi].priority = this.value;
+        syncJsonFromRoadmap();
+      });
+
+      const sizeSel = makeSelect(SIZE_OPTIONS, feature.size);
+      sizeSel.addEventListener("change", function() {
+        roadmapState[fi].size = this.value;
+        syncJsonFromRoadmap();
+      });
+
+      const engSel = makeSelect(SIZE_OPTIONS, feature.estimates?.eng ?? "");
+      engSel.addEventListener("change", function() {
+        roadmapState[fi].estimates = roadmapState[fi].estimates ?? {};
+        roadmapState[fi].estimates.eng = this.value;
+        syncJsonFromRoadmap();
+      });
+
+      const qaSel = makeSelect(SIZE_OPTIONS, feature.estimates?.qa ?? "");
+      qaSel.addEventListener("change", function() {
+        roadmapState[fi].estimates = roadmapState[fi].estimates ?? {};
+        roadmapState[fi].estimates.qa = this.value;
+        syncJsonFromRoadmap();
+      });
+
+      const devopsSel = makeSelect(SIZE_OPTIONS, feature.estimates?.devops ?? "");
+      devopsSel.addEventListener("change", function() {
+        roadmapState[fi].estimates = roadmapState[fi].estimates ?? {};
+        roadmapState[fi].estimates.devops = this.value;
+        syncJsonFromRoadmap();
+      });
+
+      const removeBtn = makeRemoveBtn();
+      removeBtn.addEventListener("click", function() {
+        roadmapState.splice(fi, 1);
+        renderRoadmapFeatures();
+        syncJsonFromRoadmap();
+      });
+
+      row.append(idInp, nameInp, priSel, sizeSel, engSel, qaSel, devopsSel, removeBtn);
+      container.appendChild(row);
+    });
+  }
+
+  // --- Sync: JSON -> form sections ---
   function syncFormFromJson() {
     try {
-      const editableFields = readEditableFieldsFromPayload(JSON.parse(jsonInput.value));
+      const data = JSON.parse(jsonInput.value);
+
+      // Mode / period / capacity controls
+      const editableFields = readEditableFieldsFromPayload(data);
       const formState = buildStructuredFormState(editableFields);
       formFields.mode.value = formState.planning_mode;
       formFields.horizon.value = formState.planning_horizon;
@@ -1212,13 +1632,35 @@ import {
       formFields.sprintDays.value = formState.sprint_days;
       formFields.overhead.value = formState.overhead_days_per_sprint;
       updatePeriodSelectorVisibility();
+      updateSchedulePoliciesVisibility();
+
+      // Schedule policies
+      const policy = readSchedulePolicyFromPayload(data);
+      document.getElementById("f-sp-qa").value = policy.qa !== null ? policy.qa : "";
+      document.getElementById("f-sp-devops").value = policy.devops !== null ? policy.devops : "";
+
+      // Organization
+      orgState = readOrgFromPayload(data);
+      renderOrgTeams();
+      renderOrgProfiles();
+
+      // Roadmap
+      roadmapState = readRoadmapFeaturesFromPayload(data);
+      renderRoadmapFeatures();
+
+      // Business goals
+      const goals = readBusinessGoalsFromPayload(data);
+      document.getElementById("f-bg-must-deliver").value = goals.must_deliver_feature_ids.join(", ");
+      document.getElementById("f-bg-max-util").value = goals.max_utilization !== null ? goals.max_utilization : "";
+      document.getElementById("f-bg-min-buffer").value = goals.min_buffer_ratio !== null ? goals.min_buffer_ratio : "";
     } catch(e) { /* ignore parse errors during typing */ }
   }
 
+  // --- Sync: form sections -> JSON ---
   function syncJsonFromForm() {
     try {
       const data = JSON.parse(jsonInput.value);
-      const nextData = applyEditableFieldsToPayload(data, {
+      let nextData = applyEditableFieldsToPayload(data, {
         planning_mode: formFields.mode.value,
         planning_horizon: formFields.horizon.value,
         calendar_year: formFields.calendarYear.value,
@@ -1235,17 +1677,132 @@ import {
         sprint_days: formFields.sprintDays.value,
         overhead_days_per_sprint: formFields.overhead.value,
       });
+      nextData = applySchedulePolicyToPayload(nextData, {
+        qa: document.getElementById("f-sp-qa").value !== "" ? Number(document.getElementById("f-sp-qa").value) : null,
+        devops: document.getElementById("f-sp-devops").value !== "" ? Number(document.getElementById("f-sp-devops").value) : null,
+      });
       jsonInput.value = JSON.stringify(nextData, null, 2);
       refreshValidationState();
+      updateSchedulePoliciesVisibility();
     } catch(e) { /* ignore if JSON is invalid */ }
   }
+
+  function normalizeOrgState(state) {
+    return {
+      country_profiles: state.country_profiles.map(p => {
+        const profile = {...p};
+        const vac = Number(profile.vacation_days_per_employee);
+        if (!isNaN(vac) && profile.vacation_days_per_employee !== "") profile.vacation_days_per_employee = vac;
+        const sick = Number(profile.sick_days_per_employee);
+        if (!isNaN(sick) && profile.sick_days_per_employee !== "") profile.sick_days_per_employee = sick;
+        return profile;
+      }),
+      teams: state.teams.map(team => ({
+        ...team,
+        members: (team.members ?? []).map(member => {
+          const m = {...member};
+          if (m.capacity_percent !== "" && m.capacity_percent !== undefined) {
+            const cap = Number(m.capacity_percent);
+            if (!isNaN(cap)) m.capacity_percent = cap;
+          } else {
+            delete m.capacity_percent;
+          }
+          return m;
+        }),
+      })),
+    };
+  }
+
+  function syncJsonFromOrg() {
+    try {
+      const data = JSON.parse(jsonInput.value);
+      jsonInput.value = JSON.stringify(applyOrgToPayload(data, normalizeOrgState(orgState)), null, 2);
+      refreshValidationState();
+    } catch(e) {}
+  }
+
+  function syncJsonFromRoadmap() {
+    try {
+      const data = JSON.parse(jsonInput.value);
+      jsonInput.value = JSON.stringify(applyRoadmapFeaturesToPayload(data, roadmapState), null, 2);
+      refreshValidationState();
+    } catch(e) {}
+  }
+
+  function syncJsonFromSchedulePolicy() {
+    try {
+      const data = JSON.parse(jsonInput.value);
+      const qaStr = document.getElementById("f-sp-qa").value;
+      const devopsStr = document.getElementById("f-sp-devops").value;
+      jsonInput.value = JSON.stringify(applySchedulePolicyToPayload(data, {
+        qa: qaStr !== "" ? Number(qaStr) : null,
+        devops: devopsStr !== "" ? Number(devopsStr) : null,
+      }), null, 2);
+      refreshValidationState();
+    } catch(e) {}
+  }
+
+  function syncJsonFromBusinessGoals() {
+    try {
+      const data = JSON.parse(jsonInput.value);
+      const mustStr = document.getElementById("f-bg-must-deliver").value;
+      const maxUtilStr = document.getElementById("f-bg-max-util").value;
+      const minBufStr = document.getElementById("f-bg-min-buffer").value;
+      const must_deliver_feature_ids = mustStr ? mustStr.split(",").map(s => s.trim()).filter(Boolean) : [];
+      const max_utilization = maxUtilStr !== "" ? Number(maxUtilStr) : null;
+      const min_buffer_ratio = minBufStr !== "" ? Number(minBufStr) : null;
+      let updated = applyBusinessGoalsToPayload(data, {must_deliver_feature_ids, max_utilization, min_buffer_ratio});
+      // Remove null entries from the JSON to avoid polluting clean payloads
+      if (updated.business_goals.max_utilization === null) delete updated.business_goals.max_utilization;
+      if (updated.business_goals.min_buffer_ratio === null) delete updated.business_goals.min_buffer_ratio;
+      jsonInput.value = JSON.stringify(updated, null, 2);
+      refreshValidationState();
+    } catch(e) {}
+  }
+
+  // Wire schedule policy inputs
+  ["f-sp-qa", "f-sp-devops"].forEach(id => {
+    const el = document.getElementById(id);
+    el.addEventListener("input", syncJsonFromSchedulePolicy);
+    el.addEventListener("change", syncJsonFromSchedulePolicy);
+  });
+
+  // Wire business goals inputs
+  ["f-bg-must-deliver", "f-bg-max-util", "f-bg-min-buffer"].forEach(id => {
+    const el = document.getElementById(id);
+    el.addEventListener("input", syncJsonFromBusinessGoals);
+    el.addEventListener("change", syncJsonFromBusinessGoals);
+  });
+
+  // Wire add-row buttons
+  document.getElementById("org-add-team-btn").addEventListener("click", function() {
+    orgState.teams.push({name: "", members: []});
+    renderOrgTeams();
+    syncJsonFromOrg();
+  });
+
+  document.getElementById("org-add-profile-btn").addEventListener("click", function() {
+    orgState.country_profiles.push({id: "", country_code: "", vacation_days_per_employee: "", sick_days_per_employee: ""});
+    renderOrgProfiles();
+    syncJsonFromOrg();
+  });
+
+  document.getElementById("roadmap-add-feature-btn").addEventListener("click", function() {
+    roadmapState.push({id: "", name: "", priority: "", estimates: {}});
+    renderRoadmapFeatures();
+    syncJsonFromRoadmap();
+  });
 
   formFields.horizon.addEventListener("change", function() {
     updatePeriodSelectorVisibility();
     syncJsonFromForm();
   });
+  formFields.mode.addEventListener("change", function() {
+    updateSchedulePoliciesVisibility();
+    syncJsonFromForm();
+  });
   Object.values(formFields).forEach(field => {
-    if (field !== formFields.horizon) {
+    if (field !== formFields.horizon && field !== formFields.mode) {
       field.addEventListener("change", syncJsonFromForm);
       field.addEventListener("input", syncJsonFromForm);
     }
@@ -1257,6 +1814,7 @@ import {
 
   // Initialize
   updatePeriodSelectorVisibility();
+  updateSchedulePoliciesVisibility();
   refreshValidationState();
 
   // --- Run planner ---


### PR DESCRIPTION
Closes #80

## Summary
- expand the structured editor with organization, schedule policy, roadmap, and business goal surfaces
- add round-trip helpers that preserve unknown JSON fields while keeping raw JSON authoritative
- keep schedule-policy behavior mode-aware so switching to capacity_check strips invalid schedule-only fields
- add focused ui logic coverage for the new structured editor helpers and round-trip behavior

## Verification
- node --test tests/ui_logic.test.mjs
- PYTHONPATH=src .venv/bin/python -m unittest discover -s tests
- .venv/bin/ruff check .
