### PR TITLE
Polish raw JSON workflows

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -222,6 +222,7 @@ select.example-select {
 /* Tabs */
 .tab-bar {
   display: flex;
+  align-items: center;
   gap: 0;
   border-bottom: 1px solid var(--border);
   margin-bottom: 14px;
@@ -241,8 +242,10 @@ select.example-select {
 }
 .tab-bar button.active { color: var(--accent); border-bottom-color: var(--accent); }
 .tab-bar button:hover { color: var(--text); }
+.tab-bar-actions { margin-left: auto; display: flex; gap: 6px; padding-bottom: 2px; }
 .tab-content { display: none; }
 .tab-content.active { display: block; }
+.panel-subtitle { font-size: 12px; color: var(--text-secondary); margin: 2px 0 0; }
 /* Error bar */
 .error-bar {
   display: none;
@@ -906,6 +909,10 @@ details[open] summary::before { content: "\25BC\00a0"; }
           <div class="tab-bar">
             <button class="active" data-tab="json-tab">JSON</button>
             <button data-tab="form-tab">Structured Edit</button>
+            <div class="tab-bar-actions" id="json-tab-actions">
+              <button class="btn btn-sm" id="copy-input-btn">Copy</button>
+              <button class="btn btn-sm" id="download-input-btn">Download</button>
+            </div>
           </div>
 
           <div id="json-tab" class="tab-content active">
@@ -1148,7 +1155,10 @@ details[open] summary::before { content: "\25BC\00a0"; }
         <!-- Raw JSON -->
         <section class="panel" id="json-panel">
           <div class="panel-header">
-            <h2>Raw JSON</h2>
+            <div>
+              <h2>Raw JSON</h2>
+              <p class="panel-subtitle">Full fidelity output — includes all fields not shown above</p>
+            </div>
             <div class="json-actions">
               <button class="btn btn-sm" id="copy-output-btn">Copy</button>
               <button class="btn btn-sm" id="download-output-btn">Download</button>
@@ -1288,7 +1298,7 @@ import {
 
   // --- Tab switching ---
   document.querySelectorAll(".tab-bar").forEach(bar => {
-    bar.querySelectorAll("button").forEach(btn => {
+    bar.querySelectorAll("button[data-tab]").forEach(btn => {
       btn.addEventListener("click", function() {
         const tabId = this.dataset.tab;
         const parent = this.closest(".panel-body") || this.closest(".panel");
@@ -1296,6 +1306,7 @@ import {
         this.classList.add("active");
         parent.querySelectorAll(".tab-content").forEach(tc => tc.classList.remove("active"));
         document.getElementById(tabId).classList.add("active");
+        if (typeof updateInputTabActions === "function") updateInputTabActions();
       });
     });
   });
@@ -2436,23 +2447,61 @@ import {
     c.appendChild(ul);
   }
 
-  // --- Copy / Download ---
+  // --- Copy / Download (output raw JSON panel — tab-aware) ---
+  function activeOutputJsonContent() {
+    const inputTab = document.getElementById("input-json-tab");
+    return inputTab.classList.contains("active")
+      ? { text: inputJsonSnapshot.textContent, filename: "capacity_plan_input.json" }
+      : { text: outputJson.textContent, filename: "capacity_plan_output.json" };
+  }
+
   copyBtn.addEventListener("click", function() {
-    navigator.clipboard.writeText(outputJson.textContent).then(() => {
+    const { text } = activeOutputJsonContent();
+    navigator.clipboard.writeText(text).then(() => {
       this.textContent = "Copied!";
       setTimeout(() => { this.textContent = "Copy"; }, 1500);
     });
   });
 
   downloadBtn.addEventListener("click", function() {
-    const blob = new Blob([outputJson.textContent], {type: "application/json"});
+    const { text, filename } = activeOutputJsonContent();
+    const blob = new Blob([text], {type: "application/json"});
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = "capacity_plan_output.json";
+    a.download = filename;
     a.click();
     URL.revokeObjectURL(url);
   });
+
+  // --- Copy / Download (input JSON tab) ---
+  const copyInputBtn = document.getElementById("copy-input-btn");
+  const downloadInputBtn = document.getElementById("download-input-btn");
+
+  copyInputBtn.addEventListener("click", function() {
+    navigator.clipboard.writeText(jsonInput.value).then(() => {
+      this.textContent = "Copied!";
+      setTimeout(() => { this.textContent = "Copy"; }, 1500);
+    });
+  });
+
+  downloadInputBtn.addEventListener("click", function() {
+    const blob = new Blob([jsonInput.value], {type: "application/json"});
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "capacity_plan_input.json";
+    a.click();
+    URL.revokeObjectURL(url);
+  });
+
+  // Show input tab actions only when JSON tab is active
+  const jsonTabActions = document.getElementById("json-tab-actions");
+  function updateInputTabActions() {
+    const jsonTabActive = document.getElementById("json-tab").classList.contains("active");
+    jsonTabActions.style.display = jsonTabActive ? "" : "none";
+  }
+  updateInputTabActions();
 
   // --- Escape HTML ---
   function esc(str) {


### PR DESCRIPTION
Closes #77

## Summary
- improve raw JSON affordances in the input and output workspaces
- make copy and download actions tab-aware for raw input vs output content
- clarify that the raw output panel is the full-fidelity escape hatch for fields not surfaced elsewhere

## Verification
- node --test tests/ui_logic.test.mjs
- PYTHONPATH=src .venv/bin/python -m unittest discover -s tests
- .venv/bin/ruff check .
