### PR TITLE
Add UI regression coverage for new workflow

### DIFF
--- a/tests/test_ui_spec.py
+++ b/tests/test_ui_spec.py
@@ -1,8 +1,47 @@
 import json
 import unittest
+from html.parser import HTMLParser
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+# ---------------------------------------------------------------------------
+# Minimal HTML parser used by raw-JSON HTML regression tests
+# ---------------------------------------------------------------------------
+
+class _AttrCollector(HTMLParser):
+    """Collects element IDs and data-tab buttons from HTML."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.ids: dict[str, dict] = {}          # id -> {tag, attrs}
+        self.tab_buttons: list[dict] = []       # elements with data-tab attr
+        self.tab_bar_action_ids: list[str] = [] # IDs inside .tab-bar-actions divs
+        self._in_tab_bar_actions = False
+
+    def handle_starttag(self, tag: str, attrs: list) -> None:
+        attrs_d = dict(attrs)
+        elem_id = attrs_d.get("id")
+        if elem_id:
+            self.ids[elem_id] = {"tag": tag, "attrs": attrs_d}
+        if "data-tab" in attrs_d:
+            self.tab_buttons.append({"tag": tag, **attrs_d})
+        cls = attrs_d.get("class", "")
+        if "tab-bar-actions" in cls:
+            self._in_tab_bar_actions = True
+        if self._in_tab_bar_actions and elem_id:
+            self.tab_bar_action_ids.append(elem_id)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "div":
+            self._in_tab_bar_actions = False
+
+
+def _parse_html(path: Path) -> _AttrCollector:
+    collector = _AttrCollector()
+    collector.feed(path.read_text(encoding="utf-8"))
+    return collector
 
 
 class UiSpecTests(unittest.TestCase):
@@ -148,3 +187,210 @@ class UiSpecTests(unittest.TestCase):
             spec["claude_implementation_guidance"]["implementation_order"][0],
             "establish stable input workspace and editor synchronization",
         )
+
+    # ------------------------------------------------------------------
+    # Issue #76: tightened spec contract coverage
+    # ------------------------------------------------------------------
+
+    def _load_spec(self) -> dict:
+        spec_path = PROJECT_ROOT / "specs" / "ui_handoff_v1.json"
+        with spec_path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+
+    def test_input_workspace_sections_match_spec(self) -> None:
+        spec = self._load_spec()
+        input_region = spec["information_architecture"]["regions"][0]
+        self.assertEqual(input_region["id"], "input_workspace")
+        self.assertEqual(
+            input_region["sections"],
+            [
+                "example_loader",
+                "mode_and_period",
+                "capacity_controls",
+                "organization",
+                "roadmap",
+                "business_goals",
+                "raw_input_json",
+            ],
+        )
+
+    def test_raw_json_panel_spec_lists_all_four_capabilities(self) -> None:
+        spec = self._load_spec()
+        panels = spec["ui_surfaces"][0]["panels"]
+        json_panel = next(p for p in panels if p["id"] == "json_panel")
+        caps = json_panel["capabilities"]
+        for required in (
+            "show_input_json", "show_output_json", "copy_output_json", "download_output_json"
+        ):
+            self.assertIn(required, caps, f"json_panel capability {required!r} missing from spec")
+
+    def test_spec_interaction_rules_include_raw_json_escape_hatch(self) -> None:
+        spec = self._load_spec()
+        rules = spec["validation_behavior"]["interaction_rules"]
+        self.assertIn("raw_json_editor_remains_available_as_fidelity_escape_hatch", rules)
+
+    def test_planning_schedule_output_fields_include_dependency_keys(self) -> None:
+        spec = self._load_spec()
+        ps_fields = spec["output_contract"]["planning_schedule_top_level_fields"]
+        self.assertIn("dependency_rules_pass", ps_fields)
+        self.assertIn("dependency_violations", ps_fields)
+        self.assertIn("function_capacity_fit", ps_fields)
+
+    def test_spec_evaluated_plan_schedule_only_fields(self) -> None:
+        spec = self._load_spec()
+        self.assertEqual(
+            spec["output_contract"]["evaluated_plan_schedule_only_fields"],
+            ["dependency_rules_pass", "dependency_violations"],
+        )
+
+    def test_structured_editor_sections_cover_org_roadmap_goals(self) -> None:
+        spec = self._load_spec()
+        editor_sections = spec["input_contract"]["structured_editor_sections"]
+        section_ids = [s["id"] for s in editor_sections]
+        for required in ("organization", "schedule_policies", "roadmap", "business_goals"):
+            self.assertIn(
+                required, section_ids,
+                f"structured_editor section {required!r} missing from spec",
+            )
+
+    def test_spec_org_section_primary_fields(self) -> None:
+        spec = self._load_spec()
+        editor_sections = spec["input_contract"]["structured_editor_sections"]
+        org_section = next(s for s in editor_sections if s["id"] == "organization")
+        for field in (
+            "rd_org.teams[].name",
+            "rd_org.teams[].members[].id",
+            "rd_org.teams[].members[].function",
+        ):
+            self.assertIn(field, org_section["primary_fields"])
+
+    def test_spec_schedule_policies_section_primary_fields(self) -> None:
+        spec = self._load_spec()
+        editor_sections = spec["input_contract"]["structured_editor_sections"]
+        sp_section = next(s for s in editor_sections if s["id"] == "schedule_policies")
+        self.assertIn(
+            "rd_org.org_schedule_policies.post_dev_min_ratio.qa",
+            sp_section["primary_fields"],
+        )
+        self.assertIn(
+            "rd_org.org_schedule_policies.post_dev_min_ratio.devops",
+            sp_section["primary_fields"],
+        )
+
+    def test_spec_capacity_check_comparison_model(self) -> None:
+        spec = self._load_spec()
+        cc_flow = spec["mode_flows"][0]
+        self.assertEqual(cc_flow["mode"], "capacity_check")
+        self.assertEqual(cc_flow["comparison_model"], "baseline_vs_selected")
+
+    def test_spec_planning_schedule_comparison_model(self) -> None:
+        spec = self._load_spec()
+        ps_flow = spec["mode_flows"][1]
+        self.assertEqual(ps_flow["mode"], "planning_schedule")
+        self.assertEqual(ps_flow["comparison_model"], "selected_plan_primary")
+
+    def test_spec_field_presentation_primary_includes_dependency_keys(self) -> None:
+        spec = self._load_spec()
+        primary = spec["field_presentation"]["primary_output_fields"]
+        self.assertIn("dependency_rules_pass", primary)
+        self.assertIn("dependency_violations", primary)
+        self.assertIn("selected_plan.function_capacity_fit", primary)
+
+
+class RawJsonHtmlRegressionTests(unittest.TestCase):
+    """Regression tests for the raw JSON workflow added in issue #77."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.html = _parse_html(PROJECT_ROOT / "ui" / "index.html")
+
+    # --- Input JSON tab: Copy and Download buttons exist ---
+
+    def test_copy_input_button_exists(self) -> None:
+        self.assertIn("copy-input-btn", self.html.ids)
+        self.assertEqual(self.html.ids["copy-input-btn"]["tag"], "button")
+
+    def test_download_input_button_exists(self) -> None:
+        self.assertIn("download-input-btn", self.html.ids)
+        self.assertEqual(self.html.ids["download-input-btn"]["tag"], "button")
+
+    def test_input_copy_download_are_inside_tab_bar_actions(self) -> None:
+        self.assertIn("copy-input-btn", self.html.tab_bar_action_ids)
+        self.assertIn("download-input-btn", self.html.tab_bar_action_ids)
+
+    # --- Output raw JSON panel: Copy and Download buttons exist ---
+
+    def test_copy_output_button_exists(self) -> None:
+        self.assertIn("copy-output-btn", self.html.ids)
+        self.assertEqual(self.html.ids["copy-output-btn"]["tag"], "button")
+
+    def test_download_output_button_exists(self) -> None:
+        self.assertIn("download-output-btn", self.html.ids)
+        self.assertEqual(self.html.ids["download-output-btn"]["tag"], "button")
+
+    # --- Tab structure: input and output tabs exist ---
+
+    def test_json_input_tab_content_exists(self) -> None:
+        self.assertIn("json-tab", self.html.ids)
+
+    def test_form_tab_content_exists(self) -> None:
+        self.assertIn("form-tab", self.html.ids)
+
+    def test_output_json_tab_content_exists(self) -> None:
+        self.assertIn("output-json-tab", self.html.ids)
+
+    def test_input_json_tab_content_exists(self) -> None:
+        self.assertIn("input-json-tab", self.html.ids)
+
+    # --- Tab bar buttons use data-tab attribute ---
+
+    def test_json_tab_button_uses_data_tab(self) -> None:
+        tab_ids = [b["data-tab"] for b in self.html.tab_buttons]
+        self.assertIn("json-tab", tab_ids)
+
+    def test_output_json_tab_button_uses_data_tab(self) -> None:
+        tab_ids = [b["data-tab"] for b in self.html.tab_buttons]
+        self.assertIn("output-json-tab", tab_ids)
+
+    def test_input_json_tab_button_uses_data_tab(self) -> None:
+        tab_ids = [b["data-tab"] for b in self.html.tab_buttons]
+        self.assertIn("input-json-tab", tab_ids)
+
+    # --- Download filename contract locked in JS source ---
+
+    def test_input_download_filename_is_capacity_plan_input_json(self) -> None:
+        js_text = (PROJECT_ROOT / "ui" / "index.html").read_text(encoding="utf-8")
+        self.assertIn("capacity_plan_input.json", js_text)
+
+    def test_output_download_filename_is_capacity_plan_output_json(self) -> None:
+        js_text = (PROJECT_ROOT / "ui" / "index.html").read_text(encoding="utf-8")
+        self.assertIn("capacity_plan_output.json", js_text)
+
+    # --- Tab-aware copy/download: activeOutputJsonContent reads active tab state ---
+
+    def test_active_output_json_content_function_present_in_js(self) -> None:
+        js_text = (PROJECT_ROOT / "ui" / "index.html").read_text(encoding="utf-8")
+        self.assertIn("activeOutputJsonContent", js_text)
+
+    def test_output_panel_checks_input_json_tab_active_class(self) -> None:
+        js_text = (PROJECT_ROOT / "ui" / "index.html").read_text(encoding="utf-8")
+        self.assertIn("input-json-tab", js_text)
+        # The JS must check classList for "active" to determine which tab is visible
+        self.assertIn("classList.contains", js_text)
+
+    # --- json-tab-actions element exists and carries correct id ---
+
+    def test_json_tab_actions_element_exists(self) -> None:
+        self.assertIn("json-tab-actions", self.html.ids)
+
+    # --- Raw JSON panel subtitle exists ---
+
+    def test_raw_json_panel_has_subtitle(self) -> None:
+        html_text = (PROJECT_ROOT / "ui" / "index.html").read_text(encoding="utf-8")
+        self.assertIn("panel-subtitle", html_text)
+
+    # --- json_panel section exists ---
+
+    def test_json_panel_section_exists(self) -> None:
+        self.assertIn("json-panel", self.html.ids)
+        self.assertEqual(self.html.ids["json-panel"]["tag"], "section")

--- a/tests/ui_logic.test.mjs
+++ b/tests/ui_logic.test.mjs
@@ -1314,3 +1314,217 @@ test("applyBusinessGoalsToPayload seeds business_goals when absent", () => {
   assert.deepEqual(updated.business_goals.must_deliver_feature_ids, ["f-99"]);
   assert.equal(updated.business_goals.max_utilization, 0.9);
 });
+
+// ============================================================
+// Issue #76 regression coverage
+// ============================================================
+
+// --- buildSummaryModel banner text variants ---
+
+test("buildSummaryModel banner is infeasible with bottleneck message when bottleneck_functions present", () => {
+  const summary = buildSummaryModel({
+    planning_mode: "capacity_check",
+    capacity_dev_days: 80,
+    selected_plan: {
+      feasibility: false,
+      bottleneck_functions: ["qa"],
+      delivered_features: [],
+      deferred_features: [],
+      dropped_features: [],
+    },
+  });
+
+  assert.equal(summary.bannerClass, "feasibility-banner infeasible");
+  assert.equal(summary.bannerText, "Plan is infeasible — function demand exceeds capacity");
+});
+
+test("buildSummaryModel banner is generic infeasible when no bottlenecks and not dep-rule failure", () => {
+  const summary = buildSummaryModel({
+    planning_mode: "capacity_check",
+    capacity_dev_days: 80,
+    selected_plan: {
+      feasibility: false,
+      bottleneck_functions: [],
+      delivered_features: [],
+      deferred_features: [],
+      dropped_features: [],
+    },
+  });
+
+  assert.equal(summary.bannerText, "Plan is infeasible — demand exceeds capacity");
+});
+
+test("buildSummaryModel banner is feasible when selected_plan is feasible and no baseline", () => {
+  const summary = buildSummaryModel({
+    planning_mode: "planning_schedule",
+    capacity_dev_days: 80,
+    selected_plan: {
+      feasibility: true,
+      delivered_features: [],
+      deferred_features: [],
+      dropped_features: [],
+    },
+  });
+
+  assert.equal(summary.bannerClass, "feasibility-banner feasible");
+  assert.equal(summary.bannerText, "Plan is feasible");
+});
+
+test("buildSummaryModel reads dependency_rules_pass from selected_plan when absent at top level", () => {
+  const summary = buildSummaryModel({
+    planning_mode: "planning_schedule",
+    capacity_dev_days: 80,
+    selected_plan: {
+      feasibility: true,
+      dependency_rules_pass: true,
+      delivered_features: [],
+      deferred_features: [],
+      dropped_features: [],
+    },
+  });
+
+  assert.equal(summary.dependencyRulesPass, true);
+});
+
+test("buildSummaryModel dependency_rules_pass false from selected_plan takes priority when absent at top level", () => {
+  const summary = buildSummaryModel({
+    planning_mode: "planning_schedule",
+    capacity_dev_days: 80,
+    selected_plan: {
+      feasibility: false,
+      dependency_rules_pass: false,
+      bottleneck_functions: [],
+      delivered_features: [],
+      deferred_features: [],
+      dropped_features: [],
+    },
+  });
+
+  assert.equal(summary.dependencyRulesPass, false);
+  assert.equal(summary.bannerText, "Plan is infeasible — dependency rules fail");
+});
+
+// --- buildModeAwareSummaryContext mode inference ---
+
+test("buildModeAwareSummaryContext infers planning_schedule from selected_plan when top-level absent", () => {
+  const ctx = buildModeAwareSummaryContext({
+    selected_plan: {planning_mode: "planning_schedule", feasibility: true},
+  });
+
+  assert.equal(ctx.planningMode, "planning_schedule");
+  assert.equal(ctx.comparisonModel, "selected_plan_primary");
+  assert.equal(ctx.showBaselineComparison, false);
+});
+
+test("buildModeAwareSummaryContext defaults to capacity_check when no mode anywhere", () => {
+  const ctx = buildModeAwareSummaryContext({});
+
+  assert.equal(ctx.planningMode, "capacity_check");
+  assert.equal(ctx.comparisonModel, "baseline_vs_selected");
+});
+
+// --- buildFunctionAnalysisModel edge cases ---
+
+test("buildFunctionAnalysisModel returns empty rows when no function data present", () => {
+  const model = buildFunctionAnalysisModel({
+    planning_mode: "capacity_check",
+    selected_plan: {feasibility: true},
+  });
+
+  assert.equal(model.rows.length, 0);
+  assert.equal(model.hasBottlenecks, false);
+  assert.deepEqual(model.bottleneckFunctions, []);
+});
+
+test("buildFunctionAnalysisModel row fits is false for function that fails capacity fit", () => {
+  const model = buildFunctionAnalysisModel({
+    planning_mode: "planning_schedule",
+    selected_plan: {
+      capacity_by_function: {eng: 80, qa: 40},
+      demand_by_function: {eng: 72, qa: 50},
+      utilization_by_function: {eng: 0.9, qa: 1.25},
+      buffer_by_function: {eng: 8, qa: -10},
+      bottleneck_functions: ["qa"],
+      function_capacity_fit: {eng: true, qa: false},
+    },
+  });
+
+  const qaRow = model.rows.find(r => r.name === "qa");
+  const engRow = model.rows.find(r => r.name === "eng");
+
+  assert.equal(qaRow.fits, false);
+  assert.equal(qaRow.isBottleneck, true);
+  assert.equal(engRow.fits, true);
+  assert.equal(engRow.isBottleneck, false);
+});
+
+test("buildFunctionAnalysisModel handles function present in fit but missing from capacity/demand", () => {
+  const model = buildFunctionAnalysisModel({
+    planning_mode: "planning_schedule",
+    capacity_by_function: {eng: 80},
+    demand_by_function: {eng: 72},
+    utilization_by_function: {eng: 0.9},
+    buffer_by_function: {eng: 8},
+    bottleneck_functions: [],
+    function_capacity_fit: {eng: true, devops: true},
+  });
+
+  // devops appears only in function_capacity_fit, not in the per-function metrics
+  // it should NOT appear as a row (rows come from the union of capacity/demand/util/buffer keys)
+  const devopsRow = model.rows.find(r => r.name === "devops");
+  assert.equal(devopsRow, undefined);
+
+  const engRow = model.rows.find(r => r.name === "eng");
+  assert.equal(engRow.fits, true);
+});
+
+// --- applySchedulePolicyToPayload: capacity_check strips existing policies ---
+
+test("applySchedulePolicyToPayload strips org_schedule_policies when capacity_check has existing policies", () => {
+  const original = {
+    planning_mode: "capacity_check",
+    rd_org: {
+      org_schedule_policies: {post_dev_min_ratio: {qa: 0.4, devops: 0.3}},
+      teams: [],
+      country_profiles: [],
+    },
+  };
+
+  const updated = applySchedulePolicyToPayload(original, {qa: 0.4, devops: 0.3});
+
+  assert.equal(updated.rd_org.org_schedule_policies, undefined);
+  assert.deepEqual(updated.rd_org.teams, []);
+});
+
+// --- applyRoadmapFeaturesToPayload: adding a feature with no prior estimates ---
+
+test("applyRoadmapFeaturesToPayload handles new feature with no existing roadmap entry", () => {
+  const original = {roadmap: {features: []}};
+  const newFeatures = [{id: "f-new", name: "New Feature", priority: "High", estimates: {eng: "M"}}];
+
+  const updated = applyRoadmapFeaturesToPayload(original, newFeatures);
+
+  assert.equal(updated.roadmap.features.length, 1);
+  assert.equal(updated.roadmap.features[0].id, "f-new");
+  assert.deepEqual(updated.roadmap.features[0].estimates, {eng: "M"});
+});
+
+// --- readOrgFromPayload / applyOrgToPayload: round-trip preserves unknown member fields ---
+
+test("applyOrgToPayload preserves unknown member fields through read-apply round-trip", () => {
+  const data = {
+    rd_org: {
+      teams: [{
+        name: "Team A",
+        members: [{id: "m1", function: "eng", seniority: "Senior", country_profile: "us", custom_tag: "alpha"}],
+      }],
+      country_profiles: [],
+    },
+  };
+
+  // applyOrgToPayload uses id-matching to retrieve original member data, so custom_tag survives
+  const org = readOrgFromPayload(data);
+  const updated = applyOrgToPayload(data, org);
+
+  assert.equal(updated.rd_org.teams[0].members[0].custom_tag, "alpha");
+});


### PR DESCRIPTION
## Summary
- expand UI regression tests for mode-aware summary and function analysis behavior
- lock typed structured-editor round trips and mode-specific schedule policy handling
- add HTML/spec regression coverage for the raw JSON workflow and UI handoff contract

## Verification
- node --test tests/ui_logic.test.mjs
- PYTHONPATH=src .venv/bin/python -m unittest discover -s tests
- .venv/bin/ruff check .

Closes #76